### PR TITLE
fix: persist tmux-resolved workdir to avoid repeated subprocess calls

### DIFF
--- a/backend/routers/sessions.py
+++ b/backend/routers/sessions.py
@@ -564,7 +564,11 @@ def get_session_workdir(name: str) -> Path:
             text=True,
         )
         if result.returncode == 0 and result.stdout.strip():
-            return Path(result.stdout.strip())
+            path = Path(result.stdout.strip())
+            # Persist so future calls skip the tmux subprocess
+            Session = Query()
+            sessions_table.upsert({"name": name, "workdir": str(path)}, Session.name == name)
+            return path
     except Exception:
         pass
 


### PR DESCRIPTION
Sessions created outside the Lumbergh UI (e.g. via bootstrap.sh) are not stored in TinyDB with a workdir. get_session_workdir() falls back to a tmux subprocess call each time, which can fail on cold start before the session is fully initialized.

Now, when the workdir is successfully resolved via tmux, it is written to TinyDB so subsequent calls use the fast stored path.