### PR TITLE
fix(ui): Use pointer:coarse for touch detection on Windows

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -59,10 +59,15 @@ export default memo(function Terminal({
   const [hasFocus, setHasFocus] = useState(false)
 
   // Detect touch device (hide scroll controls on desktop)
-  const [isTouchDevice] = useState(
-    () =>
-      typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0)
-  )
+  const [isTouchDevice] = useState(() => {
+    if (typeof window === 'undefined') return false
+    // pointer:coarse = primary input is touch (phone/tablet)
+    // pointer:fine = primary input is mouse/trackpad (desktop, even with touch hardware)
+    if (window.matchMedia) {
+      return window.matchMedia('(pointer: coarse)').matches
+    }
+    return 'ontouchstart' in window || navigator.maxTouchPoints > 0
+  })
 
   // Send text via backend API (uses tmux send-keys which works better with Claude Code)
   const sendViaApi = useCallback(
@@ -321,7 +326,9 @@ export default memo(function Terminal({
     // bypasses mouse reporting (to tmux) and handles text selection / context
     // menu natively. Single clicks are replayed without shiftKey so they
     // still reach tmux (e.g. clicking tmux tabs).
-    const isTouch = 'ontouchstart' in window || navigator.maxTouchPoints > 0
+    const isTouch = window.matchMedia
+      ? window.matchMedia('(pointer: coarse)').matches
+      : 'ontouchstart' in window || navigator.maxTouchPoints > 0
     let bypass = false
     let clickStartX = 0
     let clickStartY = 0


### PR DESCRIPTION
## Summary
- Replaces `navigator.maxTouchPoints` / `ontouchstart` touch detection with CSS media query `(pointer: coarse)`
- On Windows, `maxTouchPoints` returns non-zero even on non-touch desktops (drivers, pen support), which disabled mouse event interception and showed mobile-only scroll buttons
- `(pointer: coarse)` only matches when the primary input is actually touch (phones/tablets), so Windows desktops correctly get mouse interception behavior

## Test plan
- [ ] Windows Chrome: drag to select text in terminal — should get native blue selection, not tmux copy-mode
- [ ] Windows Chrome: right-click shows browser context menu only, not tmux popup
- [ ] Windows Chrome: scroll mode does not show ChevronUp/ChevronDown buttons
- [ ] Mac/Linux: no behavior change (pointer:coarse is false on desktop)
- [ ] Mobile/tablet: touch behavior still works as before (pointer:coarse is true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)