### PR TITLE
feat(ui): Add starred sessions with priority cycling

### DIFF
--- a/backend/lumbergh/models.py
+++ b/backend/lumbergh/models.py
@@ -143,6 +143,7 @@ class SessionUpdate(BaseModel):
     agentProvider: str | None = None  # noqa: N815 - API field name
     tabVisibility: dict[str, bool] | None = None  # noqa: N815 - API field name
     cloudEnabled: bool | None = None  # noqa: N815 - API field name
+    theOne: bool | None = None  # noqa: N815 - API field name
 
 
 class TodoMoveRequest(BaseModel):

--- a/backend/lumbergh/routers/sessions.py
+++ b/backend/lumbergh/routers/sessions.py
@@ -317,6 +317,7 @@ async def list_sessions():
                 "agentProvider": meta.get("agent_provider"),
                 "tabVisibility": meta.get("tab_visibility"),
                 "cloudEnabled": meta.get("cloud_enabled", False),
+                "theOne": meta.get("the_one", False),
             }
         )
 
@@ -344,6 +345,7 @@ async def list_sessions():
                     "paused": False,
                     "agentProvider": None,
                     "tabVisibility": None,
+                    "theOne": False,
                 }
             )
 
@@ -372,6 +374,23 @@ async def touch_session(name: str):
     return {"ok": True}
 
 
+def _apply_session_updates(record: dict, body: SessionUpdate) -> None:
+    """Apply non-None fields from the update body to the record."""
+    field_map = {
+        "displayName": "displayName",
+        "description": "description",
+        "paused": "paused",
+        "agentProvider": "agent_provider",
+        "tabVisibility": "tab_visibility",
+        "cloudEnabled": "cloud_enabled",
+        "theOne": "the_one",
+    }
+    for attr, key in field_map.items():
+        value = getattr(body, attr)
+        if value is not None:
+            record[key] = value
+
+
 @router.patch("/{name}")
 async def update_session(name: str, body: SessionUpdate):
     """Update session metadata (e.g., displayName)."""
@@ -387,19 +406,7 @@ async def update_session(name: str, body: SessionUpdate):
         # Create a new record for the orphan session
         record = {"name": name}
 
-    # Update fields
-    if body.displayName is not None:
-        record["displayName"] = body.displayName
-    if body.description is not None:
-        record["description"] = body.description
-    if body.paused is not None:
-        record["paused"] = body.paused
-    if body.agentProvider is not None:
-        record["agent_provider"] = body.agentProvider
-    if body.tabVisibility is not None:
-        record["tab_visibility"] = body.tabVisibility
-    if body.cloudEnabled is not None:
-        record["cloud_enabled"] = body.cloudEnabled
+    _apply_session_updates(record, body)
 
     sessions_table.upsert(record, session_q.name == name)
 

--- a/docs/features/the-one.md
+++ b/docs/features/the-one.md
@@ -1,0 +1,132 @@
+# Feature Spec: "The One"
+
+**Status:** Draft
+**Date:** 2026-03-30
+
+## Summary
+
+A single session can be designated as "the one" — the highest-priority conversation. This surfaces across the UI to minimize idle time on the most important session: it sorts first on the dashboard, pins to the left of the navigation dots, and gets priority in session cycling.
+
+## Motivation
+
+When managing multiple agent sessions, one conversation is often the critical path. Today, all sessions are treated equally — sorted by recency, cycled alphabetically. "The One" lets the user signal which session matters most, so the UI actively helps them return to it the moment it needs attention.
+
+## Requirements
+
+### Data Model
+
+- New boolean field `theOne` on session metadata (persisted in TinyDB `sessions.json`)
+- Multiple sessions can be starred simultaneously
+- Can be toggled off individually (zero sessions starred is valid)
+
+### Backend Changes
+
+**File:** `backend/lumbergh/routers/sessions.py`
+
+- Add `theOne: Optional[bool]` to the `SessionUpdate` Pydantic model
+- On `PATCH /api/sessions/{name}` with `theOne: true/false`:
+  - Set/clear `the_one` on the target session (no mutual exclusivity)
+- Expose `theOne` in the `GET /api/sessions` response (merged from stored metadata)
+
+**File:** `backend/lumbergh/models.py`
+
+- Add `the_one: Optional[bool]` to relevant Pydantic models
+
+### Frontend Changes
+
+#### 1. SessionCard Button (Dashboard)
+
+**File:** `frontend/src/components/SessionCard.tsx`
+
+- Add a "The One" toggle button in the card footer, next to the existing cloud icon
+- **Icon:** Lucide `Star` icon (14px), matching existing cloud icon pattern
+- **States:**
+  - **Off:** `text-text-muted` (gray), star outline only, `hover:text-blue-400`
+  - **On:** `text-blue-400` (light mode) / `text-blue-300` (dark mode), star filled with `currentColor`
+- Click calls `PATCH /api/sessions/{name}` with `{ theOne: !current }`
+- Stop event propagation (same pattern as cloud button)
+
+#### 2. Session Card Blue Border (Dashboard)
+
+**File:** `frontend/src/components/SessionCard.tsx`
+
+- When a session is "the one," apply a blue border highlight:
+  - Light mode: `border-blue-500`
+  - Dark mode: `border-blue-400` (brighter blue for visibility)
+- This replaces/overrides the default card border, not the status dot colors
+
+#### 3. Dashboard Sort Order
+
+**File:** `frontend/src/pages/Dashboard.tsx`
+
+- In the active sessions list, "the one" always sorts first
+- Remaining sessions continue to sort by `lastUsedAt` descending
+- Sort logic: `theOne` sessions first, then by `lastUsedAt`
+
+#### 4. Navigation Dots (Session Detail)
+
+**File:** `frontend/src/components/SessionNavigatorDots.tsx`
+
+- All starred dots are positioned at the far left
+- A small vertical separator bar sits between the starred dots and the rest
+- Remaining dots maintain their current order (alphabetical)
+- The entire group (dot + separator + dots) remains centered in the header
+- If no session is starred, no separator is shown, dots render as today
+- Starred dots have a subtle blue ring/accent to distinguish them (in addition to the normal status color)
+
+#### 5. Session Cycling Logic
+
+**File:** `frontend/src/pages/SessionDetail.tsx` (handleCycleSession)
+
+Current behavior:
+1. Get alive, non-paused sessions sorted alphabetically
+2. Cycle to next/previous by index
+
+New behavior:
+1. Get alive, non-paused sessions
+2. If cycling forward and any starred sessions are **idle** (waiting for input) and not the current session:
+   - Navigate to the first idle starred session
+3. Otherwise, cycle normally through the remaining sessions (alphabetical)
+4. Shift+click (previous) cycles normally without "the one" priority — this is an intentional escape hatch
+
+This means: every time you click forward from any session, if "the one" is idle, you land there first. Then the next click continues the normal cycle.
+
+## UI Mockup (Navigation Dots)
+
+```
+No "the one" set (current behavior):
+         ● ● ● ● ●
+
+"The one" set (session B is the one, currently viewing session D):
+       ◉ │ ● ● ● ●
+       B    A C D E
+```
+
+- `◉` = "the one" dot (blue accent ring)
+- `│` = vertical separator
+- `●` = normal session dot (colored by status)
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| "The one" session is killed/dies | `theOne` flag persists in TinyDB. If session appears in inactive list, no special treatment. Flag clears naturally on delete. |
+| "The one" session is paused | Excluded from cycling (same as today for paused sessions). Still shows blue border on dashboard card. Dot still pinned left but grayed. |
+| Only one active session | Dots section shows single dot, no separator needed. Cycling disabled (same as today). |
+| "The one" is the current session and you cycle forward | Normal cycle — skip "the one" priority check since you're already there. |
+| Delete "the one" session | Flag removed with the session. No "the one" is set. |
+
+## Implementation Order
+
+1. **Backend:** Add `theOne` field to model, update PATCH endpoint with mutual exclusivity logic, expose in GET response
+2. **Frontend — Icon:** Create `TheOneIcon` SVG component
+3. **Frontend — SessionCard:** Add toggle button + blue border
+4. **Frontend — Dashboard:** Update sort order
+5. **Frontend — Dots:** Pin "the one" left with separator
+6. **Frontend — Cycling:** Update `handleCycleSession` with priority logic
+
+## Non-Goals
+
+- No keyboard shortcut for toggling "the one" (can add later)
+- No notification/sound when "the one" becomes idle (future enhancement)
+- No "the one" concept for inactive/dead sessions

--- a/frontend/src/components/SessionCard.tsx
+++ b/frontend/src/components/SessionCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { getApiBase } from '../config'
-import { Minus, Pause, Play, AlertCircle, AlertTriangle, Circle, Cloud } from 'lucide-react'
+import { Minus, Pause, Play, AlertCircle, AlertTriangle, Circle, Cloud, Star } from 'lucide-react'
 import SessionCardEditForm from './SessionCardEditForm'
 import SessionCardActions from './SessionCardActions'
 import SessionCardBadges from './SessionCardBadges'
@@ -22,6 +22,7 @@ interface Session extends SessionBase {
   agentProvider?: string | null
   tabVisibility?: Record<string, boolean> | null
   cloudEnabled?: boolean
+  theOne?: boolean
 }
 
 const statusIcons = {
@@ -46,16 +47,19 @@ interface SessionUpdate {
   paused?: boolean
   agentProvider?: string
   cloudEnabled?: boolean
+  theOne?: boolean
 }
 
 function SessionCardFooter({
   session,
   cloudAtLimit,
   onToggleCloud,
+  onToggleTheOne,
 }: {
-  session: Pick<Session, 'windows' | 'attached' | 'workdir' | 'cloudEnabled'>
+  session: Pick<Session, 'windows' | 'attached' | 'workdir' | 'cloudEnabled' | 'theOne'>
   cloudAtLimit?: boolean
   onToggleCloud: (e: React.MouseEvent) => void
+  onToggleTheOne: (e: React.MouseEvent) => void
 }) {
   return (
     <div className="flex items-center gap-3 text-xs text-text-muted">
@@ -65,8 +69,19 @@ function SessionCardFooter({
       {session.attached && <span className="text-blue-400">attached</span>}
       {!session.workdir && <span className="text-yellow-500">orphan</span>}
       <button
-        onClick={onToggleCloud}
+        onClick={onToggleTheOne}
         className={`ml-auto p-0.5 rounded transition-colors ${
+          session.theOne
+            ? 'text-yellow-400 hover:text-yellow-300'
+            : 'text-text-muted hover:text-yellow-400'
+        }`}
+        title={session.theOne ? 'Starred (click to unstar)' : 'Star session'}
+      >
+        <Star size={14} fill={session.theOne ? 'currentColor' : 'none'} />
+      </button>
+      <button
+        onClick={onToggleCloud}
+        className={`p-0.5 rounded transition-colors ${
           session.cloudEnabled
             ? 'text-blue-400 hover:text-blue-300'
             : cloudAtLimit
@@ -164,6 +179,11 @@ export default function SessionCard({ session, onDelete, onUpdate, onReset, clou
     onUpdate(session.name, { cloudEnabled: !session.cloudEnabled })
   }
 
+  const handleToggleTheOne = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onUpdate(session.name, { theOne: !session.theOne })
+  }
+
   const handleEditClick = (e: React.MouseEvent) => {
     e.stopPropagation()
     setIsEditing(true)
@@ -193,7 +213,7 @@ export default function SessionCard({ session, onDelete, onUpdate, onReset, clou
     <div
       onClick={handleClick}
       data-testid="session-card-link"
-      className={`bg-bg-surface rounded-lg p-4 cursor-pointer hover:bg-bg-elevated transition-colors border border-border-default hover:border-border-subtle ${session.paused ? 'opacity-50' : ''}`}
+      className={`bg-bg-surface rounded-lg p-4 cursor-pointer hover:bg-bg-elevated transition-colors border ${session.theOne ? 'border-blue-500 dark:border-blue-400' : 'border-border-default hover:border-border-subtle'} ${session.paused ? 'opacity-50' : ''}`}
     >
       <div className="flex items-start justify-between mb-2">
         <div className="flex items-center gap-2 flex-1 min-w-0">
@@ -237,6 +257,7 @@ export default function SessionCard({ session, onDelete, onUpdate, onReset, clou
         session={session}
         cloudAtLimit={cloudAtLimit}
         onToggleCloud={handleToggleCloud}
+        onToggleTheOne={handleToggleTheOne}
       />
     </div>
   )

--- a/frontend/src/components/SessionNavigatorDots.tsx
+++ b/frontend/src/components/SessionNavigatorDots.tsx
@@ -96,8 +96,8 @@ export default function SessionNavigatorDots({ currentSessionName, compact = fal
           title={`${s.displayName || s.name} — ${status.label}`}
           className={`shrink-0 rounded-full transition-all ${colors.dot} flex items-center justify-center font-bold text-black/60 text-[8px] ${
             isCurrent
-              ? `w-6 h-6 ring-2 ${statusRingClasses[status.color]} ring-offset-1 ring-offset-[var(--bg-surface)]`
-              : 'w-5 h-5 hover:scale-110'
+              ? `w-6 h-6 ring-2 ${s.theOne ? 'ring-blue-400' : statusRingClasses[status.color]} ring-offset-1 ring-offset-[var(--bg-surface)]`
+              : `w-5 h-5 hover:scale-110${s.theOne ? ' ring-1 ring-blue-400/50' : ''}`
           } ${isPulsing ? 'animate-[pulse-dot_1.2s_ease-in-out_3]' : ''}`}
         >
           {getInitial(s.displayName || s.name)}
@@ -112,8 +112,8 @@ export default function SessionNavigatorDots({ currentSessionName, compact = fal
         title={`${s.displayName || s.name} — ${status.label}`}
         className={`rounded-full transition-all ${colors.dot} flex items-center justify-center font-bold text-black/60 ${
           isCurrent
-            ? `w-7 h-7 text-sm ring-2 ${statusRingClasses[status.color]} ring-offset-1 ring-offset-[var(--bg-surface)]`
-            : 'w-7 h-7 text-sm hover:scale-110'
+            ? `w-7 h-7 text-sm ring-2 ${s.theOne ? 'ring-blue-400' : statusRingClasses[status.color]} ring-offset-1 ring-offset-[var(--bg-surface)]`
+            : `w-7 h-7 text-sm hover:scale-110${s.theOne ? ' ring-1 ring-blue-400/50' : ''}`
         } ${isPulsing ? 'animate-[pulse-dot_1.2s_ease-in-out_3]' : ''}`}
       >
         {getInitial(s.displayName || s.name)}
@@ -121,13 +121,31 @@ export default function SessionNavigatorDots({ currentSessionName, compact = fal
     )
   })
 
+  const starredNames = new Set(sessions.filter((s) => s.theOne).map((s) => s.name))
+  const starredDots = dots.filter((d) => starredNames.has(d.key as string))
+  const restDots = dots.filter((d) => !starredNames.has(d.key as string))
+
   if (compact) {
-    return <div className="flex items-center gap-1 shrink-0">{dots}</div>
+    return (
+      <div className="flex items-center gap-1 shrink-0">
+        {starredDots}
+        {starredDots.length > 0 && restDots.length > 0 && (
+          <div className="w-0.5 h-3.5 bg-text-secondary/50 mx-1 shrink-0 rounded-full" />
+        )}
+        {restDots}
+      </div>
+    )
   }
 
   return (
     <div className="flex-1 flex items-center justify-center">
-      <div className="flex items-center gap-1.5">{dots}</div>
+      <div className="flex items-center gap-1.5">
+        {starredDots}
+        {starredDots.length > 0 && restDots.length > 0 && (
+          <div className="w-0.5 h-4 bg-text-secondary/50 mx-1 shrink-0 rounded-full" />
+        )}
+        {restDots}
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -35,6 +35,7 @@ interface Session extends SessionBase {
   agentProvider?: string | null
   tabVisibility?: Record<string, boolean> | null
   cloudEnabled?: boolean
+  theOne?: boolean
 }
 
 interface PlanInfo {
@@ -62,14 +63,18 @@ function SessionGrid({
       agentProvider?: string
       tabVisibility?: Record<string, boolean>
       cloudEnabled?: boolean
+      theOne?: boolean
     }
   ) => void
   onReset: (name: string) => void
 }) {
-  const sortByLastUsed = (a: Session, b: Session) =>
-    (b.lastUsedAt || '').localeCompare(a.lastUsedAt || '')
-  const alive = sessions.filter((s) => s.alive).sort(sortByLastUsed)
-  const dead = sessions.filter((s) => !s.alive).sort(sortByLastUsed)
+  const sortSessions = (a: Session, b: Session) => {
+    if (a.theOne && !b.theOne) return -1
+    if (!a.theOne && b.theOne) return 1
+    return (b.lastUsedAt || '').localeCompare(a.lastUsedAt || '')
+  }
+  const alive = sessions.filter((s) => s.alive).sort(sortSessions)
+  const dead = sessions.filter((s) => !s.alive).sort(sortSessions)
 
   return (
     <>
@@ -142,6 +147,7 @@ function DashboardContent({
       agentProvider?: string
       tabVisibility?: Record<string, boolean>
       cloudEnabled?: boolean
+      theOne?: boolean
     }
   ) => void
   onReset: (name: string) => void
@@ -539,6 +545,7 @@ export default function Dashboard() {
       agentProvider?: string
       tabVisibility?: Record<string, boolean>
       cloudEnabled?: boolean
+      theOne?: boolean
     }
   ) => {
     try {

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -286,13 +286,25 @@ export default function SessionDetail() {
         const data = await res.json()
         const active = (data.sessions || [])
           .filter((s: { alive: boolean; paused?: boolean }) => s.alive && !s.paused)
-          .map((s: { name: string }) => s.name)
-          .sort()
+          .sort((a: { name: string }, b: { name: string }) => a.name.localeCompare(b.name))
         if (active.length <= 1) return
-        const currentIdx = active.indexOf(name)
+        const currentIdx = active.findIndex((s: { name: string }) => s.name === name)
+
+        // On forward cycle, check starred sessions first — visit the first idle one
+        if (direction === 'next') {
+          const starredIdle = active.filter(
+            (s: { name: string; theOne?: boolean; idleState?: string }) =>
+              s.theOne && s.name !== name && s.idleState === 'idle'
+          )
+          if (starredIdle.length > 0) {
+            navigate(`/session/${starredIdle[0].name}`)
+            return
+          }
+        }
+
         const step = direction === 'next' ? 1 : active.length - 1
         const nextIdx = (currentIdx + step) % active.length
-        navigate(`/session/${active[nextIdx]}`)
+        navigate(`/session/${active[nextIdx].name}`)
       } catch {
         // Ignore errors
       }

--- a/frontend/src/utils/sessionStatus.ts
+++ b/frontend/src/utils/sessionStatus.ts
@@ -4,6 +4,7 @@ export interface SessionBase {
   idleState?: 'unknown' | 'idle' | 'working' | 'error' | 'stalled' | null
   paused?: boolean
   displayName: string | null
+  theOne?: boolean
 }
 
 export function getSessionStatus(session: SessionBase): {


### PR DESCRIPTION
## Summary
- **Star button** on session cards (yellow star icon, next to cloud icon) to mark sessions as high priority
- **Blue border** highlights starred session cards on the dashboard
- **Dashboard sort** — starred sessions always appear first
- **Navigation dots** — starred sessions pin to the left with a vertical separator
- **Priority cycling** — forward-cycling checks starred idle sessions first before normal rotation
- Multiple sessions can be starred simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)