### PR TITLE
Fix idle detection scoring and add session navigator dots

### DIFF
--- a/backend/lumbergh/idle_detector.py
+++ b/backend/lumbergh/idle_detector.py
@@ -49,6 +49,7 @@ class IdleDetector:
         re.compile(r"esc to (interrupt|cancel)", re.IGNORECASE),  # Actively processing
         re.compile(r"Reading|Writing|Searching", re.IGNORECASE),  # Cursor agent tool usage
         re.compile(r"Working \(\d+s", re.IGNORECASE),  # Codex CLI working indicator
+        re.compile(r"◼\s"),  # Claude Code subagent task in progress
     ]
 
     # Patterns indicating idle state (waiting for user input)
@@ -197,7 +198,7 @@ class IdleDetector:
         """
         Analyze buffer to determine current state.
 
-        Priority: ERROR > shell prompt > spinner > IDLE (last 3 lines) > WORKING > IDLE > UNKNOWN
+        Priority: ERROR > shell prompt > spinner > WORKING > IDLE (last 3 lines) > IDLE > UNKNOWN
         """
         if not self._buffer:
             return SessionState.UNKNOWN, 0.0, "No data"
@@ -220,16 +221,17 @@ class IdleDetector:
         if any(char in last_line for char in self.SPINNER_CHARS):
             return SessionState.WORKING, 0.95, "Spinner detected"
 
-        # 4. Idle patterns on most recent lines (current screen state wins)
+        # 4. Working patterns across all recent lines (checked before narrow
+        #    idle check so that subagent activity isn't masked by the prompt)
+        match = self._match_patterns(recent_lines, self.WORKING_PATTERNS)
+        if match:
+            return SessionState.WORKING, 0.85, f"Working pattern: {match.pattern}"
+
+        # 5. Idle patterns on most recent lines (current screen state wins)
         last_few = recent_lines[-3:]
         match = self._match_patterns(last_few, self.IDLE_PATTERNS)
         if match:
             return SessionState.IDLE, 0.9, f"Idle pattern: {match.pattern}"
-
-        # 5. Working patterns (across all recent lines)
-        match = self._match_patterns(recent_lines, self.WORKING_PATTERNS)
-        if match:
-            return SessionState.WORKING, 0.85, f"Working pattern: {match.pattern}"
 
         # 6. Idle patterns (across all recent lines, lower priority)
         match = self._match_patterns(recent_lines, self.IDLE_PATTERNS)

--- a/backend/lumbergh/idle_detector.py
+++ b/backend/lumbergh/idle_detector.py
@@ -46,7 +46,7 @@ class IdleDetector:
         re.compile(r"⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏"),  # Spinner chars
         re.compile(r"Running…|Executing"),  # Tool execution
         re.compile(r"thought for \d+s"),  # "thought for Xs" indicator
-        re.compile(r"esc to (interrupt|cancel)", re.IGNORECASE),  # Actively processing
+        re.compile(r"esc to interrupt", re.IGNORECASE),  # Actively processing
         re.compile(r"Reading|Writing|Searching", re.IGNORECASE),  # Cursor agent tool usage
         re.compile(r"Working \(\d+s", re.IGNORECASE),  # Codex CLI working indicator
         re.compile(r"◼\s"),  # Claude Code subagent task in progress
@@ -194,11 +194,69 @@ class IdleDetector:
                 return True
         return False
 
+    @staticmethod
+    def _recency_multiplier(distance_from_end: int) -> float:
+        """Return scoring multiplier based on line recency."""
+        if distance_from_end == 0:
+            return 2.0
+        if distance_from_end <= 2:
+            return 1.5
+        return 1.0
+
+    # Scoring weights
+    _BASE_WEIGHT = 3.0  # Per-pattern match
+    _SPINNER_WEIGHT = 8.0  # Spinner on last line (unambiguous)
+    _PROMPT_WEIGHT = 8.0  # Agent prompt on last line (unambiguous)
+
+    def _score_lines(
+        self, recent_lines: list[str]
+    ) -> tuple[dict[SessionState, float], dict[SessionState, list[str]]]:
+        """Score recent lines against WORKING and IDLE patterns with recency bias."""
+        scores: dict[SessionState, float] = {
+            SessionState.WORKING: 0.0,
+            SessionState.IDLE: 0.0,
+        }
+        reasons: dict[SessionState, list[str]] = {
+            SessionState.WORKING: [],
+            SessionState.IDLE: [],
+        }
+        last_line = recent_lines[-1] if recent_lines else ""
+        num_lines = len(recent_lines)
+
+        # Special: spinner on last line
+        if any(char in last_line for char in self.SPINNER_CHARS):
+            scores[SessionState.WORKING] += self._SPINNER_WEIGHT
+            reasons[SessionState.WORKING].append("Spinner on last line")
+
+        # Special: agent prompt on last line
+        if self.PROMPT_PATTERN.search(last_line):
+            scores[SessionState.IDLE] += self._PROMPT_WEIGHT
+            reasons[SessionState.IDLE].append("Agent prompt on last line")
+
+        # Score each line against all patterns
+        for i, line in enumerate(recent_lines):
+            dist = num_lines - 1 - i
+            mult = self._recency_multiplier(dist)
+
+            for pattern in self.WORKING_PATTERNS:
+                if pattern.search(line):
+                    scores[SessionState.WORKING] += self._BASE_WEIGHT * mult
+                    reasons[SessionState.WORKING].append(f"{pattern.pattern} (line -{dist})")
+
+            for pattern in self.IDLE_PATTERNS:
+                if pattern.search(line):
+                    scores[SessionState.IDLE] += self._BASE_WEIGHT * mult
+                    reasons[SessionState.IDLE].append(f"{pattern.pattern} (line -{dist})")
+
+        return scores, reasons
+
     def _analyze_state(self) -> tuple[SessionState, float, str]:
         """
-        Analyze buffer to determine current state.
+        Analyze buffer to determine current state using score-based detection.
 
-        Priority: ERROR > shell prompt > spinner > WORKING > IDLE (last 3 lines) > IDLE > UNKNOWN
+        ERROR and shell prompt are short-circuited (unambiguous).
+        WORKING vs IDLE is resolved by scoring: each pattern match adds a
+        weighted score (with recency bias), and the highest total wins.
         """
         if not self._buffer:
             return SessionState.UNKNOWN, 0.0, "No data"
@@ -206,39 +264,31 @@ class IdleDetector:
         recent_lines = list(self._buffer)[-10:]
         last_line = recent_lines[-1] if recent_lines else ""
 
-        # 1. Error patterns (highest priority)
+        # 1. Error patterns (short-circuit — unambiguous)
         match = self._match_patterns(recent_lines, self.ERROR_PATTERNS)
         if match:
             return SessionState.ERROR, 0.9, f"Error pattern: {match.pattern}"
 
-        # 2. Shell prompt (only if no working/idle indicators)
+        # 2. Shell prompt (short-circuit — depends on absence of indicators)
         if not self._has_activity_indicators(recent_lines):
             match = self._match_patterns([last_line], self.SHELL_PROMPT_PATTERNS)
             if match:
                 return SessionState.ERROR, 0.85, f"Shell prompt: {match.pattern}"
 
-        # 3. Spinner on last line
-        if any(char in last_line for char in self.SPINNER_CHARS):
-            return SessionState.WORKING, 0.95, "Spinner detected"
+        # 3. Score-based WORKING vs IDLE detection
+        scores, reasons = self._score_lines(recent_lines)
+        w_score = scores[SessionState.WORKING]
+        i_score = scores[SessionState.IDLE]
 
-        # 4. Working patterns across all recent lines (checked before narrow
-        #    idle check so that subagent activity isn't masked by the prompt)
-        match = self._match_patterns(recent_lines, self.WORKING_PATTERNS)
-        if match:
-            return SessionState.WORKING, 0.85, f"Working pattern: {match.pattern}"
+        if w_score == 0.0 and i_score == 0.0:
+            return SessionState.UNKNOWN, 0.3, "No patterns matched"
 
-        # 5. Idle patterns on most recent lines (current screen state wins)
-        last_few = recent_lines[-3:]
-        match = self._match_patterns(last_few, self.IDLE_PATTERNS)
-        if match:
-            return SessionState.IDLE, 0.9, f"Idle pattern: {match.pattern}"
-
-        # 6. Idle patterns (across all recent lines, lower priority)
-        match = self._match_patterns(recent_lines, self.IDLE_PATTERNS)
-        if match:
-            return SessionState.IDLE, 0.8, f"Idle pattern: {match.pattern}"
-
-        return SessionState.UNKNOWN, 0.3, "Unable to determine"
+        total = w_score + i_score
+        if w_score >= i_score:
+            top = "; ".join(reasons[SessionState.WORKING][:3])
+            return SessionState.WORKING, min(0.95, w_score / total), f"Working: {top}"
+        top = "; ".join(reasons[SessionState.IDLE][:3])
+        return SessionState.IDLE, min(0.95, i_score / total), f"Idle: {top}"
 
     @staticmethod
     def _strip_ansi(text: str) -> str:

--- a/backend/lumbergh/idle_monitor.py
+++ b/backend/lumbergh/idle_monitor.py
@@ -29,6 +29,7 @@ class IdleMonitor:
 
     POLL_INTERVAL_SECONDS = 2.0  # How often to check sessions
     STALL_THRESHOLD_SECONDS = 600
+    SUBAGENT_STALL_THRESHOLD_SECONDS = 1800  # 30 min for subagent work
 
     def __init__(self):
         self._detectors: dict[str, IdleDetector] = {}
@@ -124,10 +125,17 @@ class IdleMonitor:
         if result.state == SessionState.WORKING:
             if session_name not in self._working_since:
                 self._working_since[session_name] = time.time()
-            elif time.time() - self._working_since[session_name] > self.STALL_THRESHOLD_SECONDS:
-                result = IdleDetectionResult(
-                    SessionState.STALLED, result.confidence, "Working too long"
+            else:
+                is_subagent = "◼" in result.reason
+                threshold = (
+                    self.SUBAGENT_STALL_THRESHOLD_SECONDS
+                    if is_subagent
+                    else self.STALL_THRESHOLD_SECONDS
                 )
+                if time.time() - self._working_since[session_name] > threshold:
+                    result = IdleDetectionResult(
+                        SessionState.STALLED, result.confidence, "Working too long"
+                    )
         else:
             self._working_since.pop(session_name, None)
 

--- a/backend/lumbergh/tests/test_idle_detector.py
+++ b/backend/lumbergh/tests/test_idle_detector.py
@@ -1,0 +1,333 @@
+"""Tests for the idle state detector scoring system."""
+
+from lumbergh.idle_detector import IdleDetector, SessionState
+
+
+def _make_detector(lines: list[str]) -> IdleDetector:
+    """Create a detector with pre-populated buffer."""
+    detector = IdleDetector()
+    for line in lines:
+        detector._buffer.append(line)
+    return detector
+
+
+# ---------------------------------------------------------------------------
+# ERROR detection
+# ---------------------------------------------------------------------------
+
+
+class TestErrorDetection:
+    def test_rate_limit(self):
+        detector = _make_detector(["Some output", "rate limit exceeded"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.ERROR
+
+    def test_429(self):
+        detector = _make_detector(["429 Too Many Requests"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.ERROR
+
+    def test_api_error(self):
+        detector = _make_detector(["APIError: connection refused"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.ERROR
+
+    def test_overloaded(self):
+        detector = _make_detector(["The server is overloaded"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.ERROR
+
+
+# ---------------------------------------------------------------------------
+# Shell prompt detection
+# ---------------------------------------------------------------------------
+
+
+class TestShellPromptDetection:
+    def test_shell_prompt_no_activity(self):
+        """Shell prompt with no agent indicators = ERROR (exited)."""
+        detector = _make_detector(["user@host:~$"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.ERROR
+
+    def test_shell_prompt_with_activity_not_error(self):
+        """Shell prompt with agent indicators should NOT be error."""
+        detector = _make_detector(["\u280b Thinking...", "user@host:~$"])
+        state, _, _ = detector._analyze_state()
+        assert state != SessionState.ERROR
+
+
+# ---------------------------------------------------------------------------
+# Spinner detection
+# ---------------------------------------------------------------------------
+
+
+class TestSpinnerDetection:
+    def test_spinner_on_last_line(self):
+        detector = _make_detector(["\u280b Processing files..."])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.WORKING
+
+
+# ---------------------------------------------------------------------------
+# Bug regression: esc to cancel
+# ---------------------------------------------------------------------------
+
+
+class TestEscToCancelBug:
+    def test_esc_to_cancel_with_idle_context_is_idle(self):
+        """The original bug: 'Esc to cancel' in an idle prompt must be IDLE."""
+        detector = _make_detector(
+            [
+                "Do you want to proceed?",
+                "Yes  No",
+                "Esc to cancel",
+                "? for shortcuts",
+            ]
+        )
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.IDLE
+
+    def test_esc_to_interrupt_is_working(self):
+        """'esc to interrupt' during active processing should be WORKING."""
+        detector = _make_detector(
+            [
+                "Thinking...",
+                "esc to interrupt",
+            ]
+        )
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.WORKING
+
+    def test_esc_to_cancel_alone_is_idle(self):
+        """'Esc to cancel' with no working context should be IDLE."""
+        detector = _make_detector(
+            [
+                "Press enter to confirm or esc to cancel",
+            ]
+        )
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.IDLE
+
+
+# ---------------------------------------------------------------------------
+# WORKING pattern detection
+# ---------------------------------------------------------------------------
+
+
+class TestWorkingDetection:
+    def test_thinking_pattern(self):
+        detector = _make_detector(["Thinking about your request..."])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.WORKING
+
+    def test_thought_for_seconds(self):
+        detector = _make_detector(["thought for 12s"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.WORKING
+
+    def test_working_seconds_pattern(self):
+        detector = _make_detector(["Working (45s"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.WORKING
+
+    def test_running_tool(self):
+        detector = _make_detector(["Running\u2026"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.WORKING
+
+    def test_subagent_marker(self):
+        detector = _make_detector(["\u25fc Running subagent task"])
+        state, _, reason = detector._analyze_state()
+        assert state == SessionState.WORKING
+        assert "\u25fc" in reason  # Critical for idle_monitor subagent detection
+
+
+# ---------------------------------------------------------------------------
+# IDLE pattern detection
+# ---------------------------------------------------------------------------
+
+
+class TestIdleDetection:
+    def test_prompt_character(self):
+        """\u276f on the last line should be IDLE."""
+        detector = _make_detector(["\u276f"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.IDLE
+
+    def test_yes_no_prompt(self):
+        detector = _make_detector(["Do you want to proceed?", "Yes  No"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.IDLE
+
+    def test_yn_prompt(self):
+        detector = _make_detector(["Continue? (y/n)"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.IDLE
+
+    def test_type_your_message(self):
+        detector = _make_detector(["Type your message"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.IDLE
+
+    def test_action_required(self):
+        detector = _make_detector(["Action Required"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.IDLE
+
+    def test_allow_once(self):
+        detector = _make_detector(["Allow once"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.IDLE
+
+
+# ---------------------------------------------------------------------------
+# Scoring / recency
+# ---------------------------------------------------------------------------
+
+
+class TestScoringRecency:
+    def test_recent_idle_beats_old_working(self):
+        """IDLE on last lines should beat a single WORKING on an old line."""
+        detector = _make_detector(
+            [
+                "Thinking...",  # WORKING, old
+                "line 2",
+                "line 3",
+                "line 4",
+                "line 5",
+                "line 6",
+                "line 7",
+                "line 8",
+                "Do you want to proceed?",  # IDLE, recent
+                "Yes  No",  # IDLE, last line
+            ]
+        )
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.IDLE
+
+    def test_recent_working_beats_old_idle(self):
+        """WORKING on last lines should beat old IDLE signals."""
+        detector = _make_detector(
+            [
+                "Do you want to proceed?",  # IDLE, old
+                "Yes  No",  # IDLE, old
+                "line 3",
+                "line 4",
+                "line 5",
+                "line 6",
+                "line 7",
+                "line 8",
+                "Thinking...",  # WORKING, recent
+                "esc to interrupt",  # WORKING, last line
+            ]
+        )
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.WORKING
+
+    def test_multiple_idle_beats_single_working(self):
+        """Multiple IDLE signals should beat a single WORKING signal."""
+        detector = _make_detector(
+            [
+                "esc to interrupt",  # WORKING
+                "Do you want to proceed?",  # IDLE
+                "Yes  No",  # IDLE
+                "? for shortcuts",  # IDLE
+            ]
+        )
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.IDLE
+
+
+# ---------------------------------------------------------------------------
+# UNKNOWN fallback
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownFallback:
+    def test_empty_buffer(self):
+        detector = IdleDetector()
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.UNKNOWN
+
+    def test_no_patterns_match(self):
+        detector = _make_detector(["random text", "more random stuff"])
+        state, _, _ = detector._analyze_state()
+        assert state == SessionState.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Recency multiplier
+# ---------------------------------------------------------------------------
+
+
+class TestRecencyMultiplier:
+    def test_last_line(self):
+        assert IdleDetector._recency_multiplier(0) == 2.0
+
+    def test_recent_lines(self):
+        assert IdleDetector._recency_multiplier(1) == 1.5
+        assert IdleDetector._recency_multiplier(2) == 1.5
+
+    def test_old_lines(self):
+        assert IdleDetector._recency_multiplier(3) == 1.0
+        assert IdleDetector._recency_multiplier(9) == 1.0
+
+
+# ---------------------------------------------------------------------------
+# process_output hysteresis
+# ---------------------------------------------------------------------------
+
+
+class TestProcessOutput:
+    def test_initial_state_is_unknown(self):
+        detector = IdleDetector()
+        assert detector.get_state() == SessionState.UNKNOWN
+
+    def test_hysteresis_delays_state_change(self):
+        """State should not change until stable for STATE_CHANGE_DELAY_MS."""
+        detector = IdleDetector()
+        detector.process_output("Thinking...")
+        # First detection starts the pending timer; current state stays UNKNOWN
+        assert detector.get_state() == SessionState.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# analyze_initial_content
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeInitialContent:
+    def test_idle_content(self):
+        detector = IdleDetector()
+        result = detector.analyze_initial_content("Some previous output\n\u276f")
+        assert result.state == SessionState.IDLE
+
+    def test_working_content(self):
+        detector = IdleDetector()
+        result = detector.analyze_initial_content("Some previous output\n\u280b Thinking...")
+        assert result.state == SessionState.WORKING
+
+    def test_error_content(self):
+        detector = IdleDetector()
+        result = detector.analyze_initial_content("APIError: connection refused")
+        assert result.state == SessionState.ERROR
+
+    def test_skips_hysteresis(self):
+        """analyze_initial_content should set state immediately."""
+        detector = IdleDetector()
+        detector.analyze_initial_content("Thinking...")
+        assert detector.get_state() == SessionState.WORKING
+
+
+# ---------------------------------------------------------------------------
+# ANSI stripping
+# ---------------------------------------------------------------------------
+
+
+class TestStripAnsi:
+    def test_strips_color_codes(self):
+        assert IdleDetector._strip_ansi("\x1b[31mred text\x1b[0m") == "red text"
+
+    def test_no_ansi_unchanged(self):
+        assert IdleDetector._strip_ansi("plain text") == "plain text"

--- a/frontend/src/utils/sessionStatus.ts
+++ b/frontend/src/utils/sessionStatus.ts
@@ -25,7 +25,7 @@ export function getSessionStatus(session: SessionBase): {
     case 'stalled':
       return { color: 'red', pulse: true, label: 'Stalled' }
     default:
-      return { color: 'green', pulse: false, label: 'Active' }
+      return { color: 'gray', pulse: false, label: 'Unknown' }
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace first-match-wins idle detection with score-based system — fixes
  false "working" status when Claude is asking a question ("esc to cancel"
  appeared in both working and idle contexts, and the working check fired first)
- Each pattern match now adds a weighted score with recency bias (last line
  counts 2x), so multiple clear idle signals override a single ambiguous match
- Default unknown/null idle state shows gray instead of green on the dashboard
- Add 37 unit tests for the idle detector covering all pattern categories,
  scoring interactions, hysteresis, and the specific bug regression

The scoring approach makes idle detection resilient to ambiguous patterns going
forward — adding new patterns no longer risks breaking detection by landing in
the wrong priority slot. Unknown states showing gray also makes detection gaps
immediately visible rather than silently showing the wrong color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)