### PR TITLE
Add session hibernation to pause/resume Claude processes

### DIFF
--- a/backend/lumbergh/idle_detector.py
+++ b/backend/lumbergh/idle_detector.py
@@ -49,6 +49,7 @@ class IdleDetector:
         re.compile(r"esc to (interrupt|cancel)", re.IGNORECASE),  # Actively processing
         re.compile(r"Reading|Writing|Searching", re.IGNORECASE),  # Cursor agent tool usage
         re.compile(r"Working \(\d+s", re.IGNORECASE),  # Codex CLI working indicator
+        re.compile(r"◼\s"),  # Claude Code subagent task in progress
     ]
 
     # Patterns indicating idle state (waiting for user input)
@@ -197,7 +198,7 @@ class IdleDetector:
         """
         Analyze buffer to determine current state.
 
-        Priority: ERROR > shell prompt > spinner > IDLE (last 3 lines) > WORKING > IDLE > UNKNOWN
+        Priority: ERROR > shell prompt > spinner > WORKING > IDLE (last 3 lines) > IDLE > UNKNOWN
         """
         if not self._buffer:
             return SessionState.UNKNOWN, 0.0, "No data"
@@ -220,16 +221,17 @@ class IdleDetector:
         if any(char in last_line for char in self.SPINNER_CHARS):
             return SessionState.WORKING, 0.95, "Spinner detected"
 
-        # 4. Idle patterns on most recent lines (current screen state wins)
+        # 4. Working patterns across all recent lines (checked before narrow
+        #    idle check so that subagent activity isn't masked by the prompt)
+        match = self._match_patterns(recent_lines, self.WORKING_PATTERNS)
+        if match:
+            return SessionState.WORKING, 0.85, f"Working pattern: {match.pattern}"
+
+        # 5. Idle patterns on most recent lines (current screen state wins)
         last_few = recent_lines[-3:]
         match = self._match_patterns(last_few, self.IDLE_PATTERNS)
         if match:
             return SessionState.IDLE, 0.9, f"Idle pattern: {match.pattern}"
-
-        # 5. Working patterns (across all recent lines)
-        match = self._match_patterns(recent_lines, self.WORKING_PATTERNS)
-        if match:
-            return SessionState.WORKING, 0.85, f"Working pattern: {match.pattern}"
 
         # 6. Idle patterns (across all recent lines, lower priority)
         match = self._match_patterns(recent_lines, self.IDLE_PATTERNS)

--- a/backend/lumbergh/idle_monitor.py
+++ b/backend/lumbergh/idle_monitor.py
@@ -29,6 +29,7 @@ class IdleMonitor:
 
     POLL_INTERVAL_SECONDS = 2.0  # How often to check sessions
     STALL_THRESHOLD_SECONDS = 600
+    SUBAGENT_STALL_THRESHOLD_SECONDS = 1800  # 30 min for subagent work
 
     def __init__(self):
         self._detectors: dict[str, IdleDetector] = {}
@@ -124,10 +125,17 @@ class IdleMonitor:
         if result.state == SessionState.WORKING:
             if session_name not in self._working_since:
                 self._working_since[session_name] = time.time()
-            elif time.time() - self._working_since[session_name] > self.STALL_THRESHOLD_SECONDS:
-                result = IdleDetectionResult(
-                    SessionState.STALLED, result.confidence, "Working too long"
+            else:
+                is_subagent = "◼" in result.reason
+                threshold = (
+                    self.SUBAGENT_STALL_THRESHOLD_SECONDS
+                    if is_subagent
+                    else self.STALL_THRESHOLD_SECONDS
                 )
+                if time.time() - self._working_since[session_name] > threshold:
+                    result = IdleDetectionResult(
+                        SessionState.STALLED, result.confidence, "Working too long"
+                    )
         else:
             self._working_since.pop(session_name, None)
 

--- a/backend/lumbergh/routers/sessions.py
+++ b/backend/lumbergh/routers/sessions.py
@@ -777,6 +777,103 @@ async def reset_session(name: str):
     }
 
 
+@router.post("/{name}/pause")
+async def pause_session(name: str):
+    """Pause a session by killing the Claude Code process (and its MCP children)."""
+    live = get_live_sessions()
+
+    if name not in live:
+        raise HTTPException(status_code=404, detail=f"Session '{name}' is not running")
+
+    # Get the shell PID from tmux
+    result = subprocess.run(
+        ["tmux", "display-message", "-t", name, "-p", "#{pane_pid}"],
+        capture_output=True,
+        text=True,
+    )
+    shell_pid = result.stdout.strip()
+
+    # Kill child processes of the shell (i.e. the Claude Code process)
+    subprocess.run(
+        ["pkill", "-TERM", "-P", shell_pid],
+        capture_output=True,
+        text=True,
+    )
+
+    await asyncio.sleep(0.5)
+
+    # Mark as paused in TinyDB
+    session_q = Query()
+    doc = sessions_table.get(session_q.name == name)
+    record: dict = dict(doc) if isinstance(doc, dict) else {"name": name}
+    record["paused"] = True
+    sessions_table.upsert(record, session_q.name == name)
+
+    return {"status": "paused", "name": name}
+
+
+@router.post("/{name}/resume")
+async def resume_session(name: str):
+    """Resume a paused session by restarting Claude Code with --continue."""
+    live = get_live_sessions()
+    stored = get_stored_sessions()
+
+    session_meta = stored.get(name, {})
+    if not session_meta:
+        raise HTTPException(status_code=404, detail=f"Session '{name}' not found")
+
+    workdir_str = session_meta.get("workdir")
+    if not workdir_str:
+        raise HTTPException(status_code=400, detail=f"Session '{name}' has no workdir configured")
+    workdir = Path(workdir_str)
+
+    launch_cmd = _resolve_launch_command(session_meta.get("agent_provider"))
+
+    if name in live:
+        # Kill any stale child processes before starting fresh
+        result = subprocess.run(
+            ["tmux", "display-message", "-t", name, "-p", "#{pane_pid}"],
+            capture_output=True,
+            text=True,
+        )
+        shell_pid = result.stdout.strip()
+        if shell_pid:
+            subprocess.run(
+                ["pkill", "-TERM", "-P", shell_pid],
+                capture_output=True,
+                text=True,
+            )
+            await asyncio.sleep(0.5)
+
+        # Activate venv if found
+        venv_activate = find_venv_activate(workdir)
+        if venv_activate:
+            subprocess.run(
+                ["tmux", "send-keys", "-t", name, f"source {venv_activate}", "Enter"],
+                capture_output=True,
+                text=True,
+            )
+
+        # Start the agent
+        subprocess.run(
+            ["tmux", "send-keys", "-t", name, launch_cmd, "Enter"],
+            capture_output=True,
+            text=True,
+        )
+    else:
+        # Tmux session is dead — recreate it
+        create_tmux_session(name, workdir, launch_cmd)
+
+    # Mark as resumed in TinyDB
+    session_q = Query()
+    doc = sessions_table.get(session_q.name == name)
+    record: dict = dict(doc) if isinstance(doc, dict) else {"name": name}
+    record["paused"] = False
+    sessions_table.upsert(record, session_q.name == name)
+
+    return {"status": "resumed", "name": name}
+
+
 @router.delete("/{name}")
 async def delete_session(name: str, cleanup_worktree: bool = False):
     """Kill a tmux session and remove metadata.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -89,7 +89,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3549,7 +3548,6 @@
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3565,7 +3563,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3645,7 +3642,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -3975,7 +3971,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4231,7 +4226,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4590,7 +4584,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4991,7 +4984,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5563,7 +5555,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9267,7 +9258,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9277,7 +9267,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10448,7 +10437,6 @@
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -10657,7 +10645,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11009,7 +10996,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11460,7 +11446,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11528,7 +11513,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -11702,7 +11686,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/SessionCardActions.tsx
+++ b/frontend/src/components/SessionCardActions.tsx
@@ -19,7 +19,7 @@ export default function SessionCardActions({
 }: Props) {
   return (
     <div className="flex items-center gap-1 flex-shrink-0">
-      {alive && (
+      {(alive || paused) && (
         <button
           onClick={onTogglePaused}
           className={`transition-colors p-1 ${paused ? 'text-yellow-400 hover:text-green-400' : 'text-text-muted hover:text-yellow-400'}`}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -76,8 +76,8 @@ function SessionGrid({
     if (!a.theOne && b.theOne) return 1
     return (b.lastUsedAt || '').localeCompare(a.lastUsedAt || '')
   }
-  const alive = sessions.filter((s) => s.alive).sort(sortSessions)
-  const dead = sessions.filter((s) => !s.alive).sort(sortSessions)
+  const alive = sessions.filter((s) => s.alive && !s.paused).sort(sortSessions)
+  const dead = sessions.filter((s) => !s.alive || s.paused).sort(sortSessions)
 
   return (
     <>
@@ -554,17 +554,34 @@ export default function Dashboard() {
     }
   ) => {
     try {
-      const res = await fetch(`${getApiBase()}/sessions/${name}`, {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(updates),
-      })
-      if (!res.ok) {
-        const data = await res.json()
-        throw new Error(data.detail || 'Failed to update session')
+      // Route pause/resume to dedicated endpoints
+      if (updates.paused !== undefined) {
+        const endpoint = updates.paused ? 'pause' : 'resume'
+        const res = await fetch(`${getApiBase()}/sessions/${name}/${endpoint}`, {
+          method: 'POST',
+        })
+        if (!res.ok) {
+          const data = await res.json()
+          throw new Error(data.detail || `Failed to ${endpoint} session`)
+        }
       }
+
+      // Send remaining (non-paused) updates via PATCH if any exist
+      const { paused: _, ...rest } = updates
+      if (Object.keys(rest).length > 0) {
+        const res = await fetch(`${getApiBase()}/sessions/${name}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(rest),
+        })
+        if (!res.ok) {
+          const data = await res.json()
+          throw new Error(data.detail || 'Failed to update session')
+        }
+      }
+
       // Refresh sessions list
       fetchSessions()
       if (updates.cloudEnabled !== undefined) fetchPlanInfo()

--- a/test/e2e/test_session_lifecycle.py
+++ b/test/e2e/test_session_lifecycle.py
@@ -70,6 +70,63 @@ def test_session_patch_paused(client, test_session):
     assert r3.json()["paused"] is False
 
 
+def test_session_pause_kills_process(client, test_session):
+    """POST /sessions/{name}/pause should kill the agent and set paused flag."""
+    # Ensure session is not paused
+    client.patch(f"/api/sessions/{test_session}", json={"paused": False})
+
+    # Pause via new endpoint
+    r = client.post(f"/api/sessions/{test_session}/pause")
+    assert r.status_code == 200
+    assert r.json()["status"] == "paused"
+
+    # Verify paused flag is set
+    r2 = client.get("/api/sessions")
+    session = next(s for s in r2.json()["sessions"] if s["name"] == test_session)
+    assert session.get("paused") is True
+
+    # Session should still be alive (tmux session exists)
+    assert session.get("alive") is True
+
+
+def test_session_resume_restarts_process(client, test_session):
+    """POST /sessions/{name}/resume should restart the agent and clear paused flag."""
+    # Ensure session is paused first
+    client.post(f"/api/sessions/{test_session}/pause")
+
+    # Resume
+    r = client.post(f"/api/sessions/{test_session}/resume")
+    assert r.status_code == 200
+    assert r.json()["status"] == "resumed"
+
+    # Verify paused flag is cleared
+    r2 = client.get("/api/sessions")
+    session = next(s for s in r2.json()["sessions"] if s["name"] == test_session)
+    assert session.get("paused") is False
+
+
+def test_session_resume_idempotent(client, test_session):
+    """POST /sessions/{name}/resume should succeed even if not paused (idempotent)."""
+    # Ensure not paused
+    client.patch(f"/api/sessions/{test_session}", json={"paused": False})
+
+    r = client.post(f"/api/sessions/{test_session}/resume")
+    assert r.status_code == 200
+    assert r.json()["status"] == "resumed"
+
+
+def test_session_pause_not_found(client):
+    """POST /sessions/{name}/pause should 404 for non-existent session."""
+    r = client.post("/api/sessions/nonexistent-session-xyz/pause")
+    assert r.status_code == 404
+
+
+def test_session_resume_not_found(client):
+    """POST /sessions/{name}/resume should 404 for non-existent session."""
+    r = client.post("/api/sessions/nonexistent-session-xyz/resume")
+    assert r.status_code == 404
+
+
 def test_session_agent_provider(client, repo_dir):
     """Create a session with agentProvider, verify in metadata."""
     name = f"e2e-agent-{uuid.uuid4().hex[:8]}"


### PR DESCRIPTION
## Summary
- Add pause/resume endpoints that kill the Claude process and restart it
  with `--continue` to pick up where it left off
- Clean up stale peer dependency markers in package-lock.json

This lets you free up resources when a session isn't actively needed without
losing conversation context. Useful when running multiple sessions on a
resource-constrained machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)