### PR TITLE
🐛 fix(sessions): surface create failures and plug copy-mode fd leak

### DIFF
--- a/backend/lumbergh/routers/sessions.py
+++ b/backend/lumbergh/routers/sessions.py
@@ -11,6 +11,7 @@ import subprocess
 import time
 import uuid
 from collections.abc import Callable
+from http import HTTPStatus
 from pathlib import Path
 from typing import TypeVar
 
@@ -567,6 +568,22 @@ def _resolve_direct_workdir(body: CreateSessionRequest) -> Path:
     return workdir
 
 
+def _spawn_tmux_or_raise(body: CreateSessionRequest, workdir: Path) -> None:
+    """Spawn the tmux session, mapping exceptions to meaningful HTTP errors."""
+    launch_cmd = _resolve_launch_command(body.agent_provider)
+    try:
+        create_tmux_session(body.name, workdir, launch_command=launch_cmd)
+    except RuntimeError as e:
+        raise HTTPException(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail=str(e))
+    except OSError as e:
+        # e.g. EMFILE "Too many open files" when the backend has leaked fds
+        raise HTTPException(
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+            detail=f"Failed to spawn tmux ({e.__class__.__name__}: {e}). "
+            "The backend may have hit its file-descriptor limit; restart it and retry.",
+        )
+
+
 def _resolve_launch_command(agent_provider: str | None) -> str:
     """Resolve the agent launch command from provider + global settings."""
     from lumbergh.routers.settings import get_settings
@@ -625,12 +642,7 @@ async def create_session(body: CreateSessionRequest):
                 "worktreeBranch": meta.get("worktree_branch"),
             }
 
-    launch_cmd = _resolve_launch_command(body.agent_provider)
-
-    try:
-        create_tmux_session(body.name, workdir, launch_command=launch_cmd)
-    except RuntimeError as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    _spawn_tmux_or_raise(body, workdir)
 
     session_q = Query()
     session_data: dict[str, object] = {

--- a/backend/lumbergh/session_manager.py
+++ b/backend/lumbergh/session_manager.py
@@ -266,6 +266,39 @@ class SessionManager:
             except Exception:  # noqa: S110 - cleanup is best-effort
                 pass
 
+    async def _poll_copy_mode(self, session_name: str) -> bool | None:
+        """Return True/False for copy-mode active, or None if the probe failed.
+
+        On failure, kill+reap the subprocess so its stdout/stderr pipes are
+        closed; otherwise the 250ms polling loop leaks two fds per failure
+        until EMFILE.
+        """
+        proc = None
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "tmux",
+                "display-message",
+                "-p",
+                "-t",
+                session_name,
+                "#{pane_mode}",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=1.0)
+            return stdout.decode().strip() == "copy-mode"
+        except (TimeoutError, OSError, ValueError):
+            if proc is not None and proc.returncode is None:
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
+                try:
+                    await proc.wait()
+                except Exception:  # noqa: S110 - best-effort reap
+                    pass
+            return None
+
     async def _copy_mode_monitor(self, session_name: str) -> None:
         """Poll tmux pane_mode every 250ms and broadcast copy-mode state changes."""
         last_active = False
@@ -275,29 +308,16 @@ class SessionManager:
                 managed = self._sessions.get(session_name)
                 if not managed or not managed.clients:
                     break
-                try:
-                    proc = await asyncio.create_subprocess_exec(
-                        "tmux",
-                        "display-message",
-                        "-p",
-                        "-t",
-                        session_name,
-                        "#{pane_mode}",
-                        stdout=asyncio.subprocess.PIPE,
-                        stderr=asyncio.subprocess.PIPE,
-                    )
-                    stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=1.0)
-                    active = stdout.decode().strip() == "copy-mode"
-                except Exception:  # noqa: S112
+                active = await self._poll_copy_mode(session_name)
+                if active is None or active == last_active:
                     continue
-                if active != last_active:
-                    last_active = active
-                    message = {"type": "copy_mode", "active": active}
-                    for client in list(managed.clients):
-                        try:
-                            await client.send_json(message)
-                        except Exception:  # noqa: S110
-                            pass
+                last_active = active
+                message = {"type": "copy_mode", "active": active}
+                for client in list(managed.clients):
+                    try:
+                        await client.send_json(message)
+                    except Exception:  # noqa: S110
+                        pass
         except asyncio.CancelledError:
             pass
 

--- a/backend/lumbergh/tests/test_endpoints.py
+++ b/backend/lumbergh/tests/test_endpoints.py
@@ -83,3 +83,39 @@ class TestFilesEndpoints:
         # If 200, it must be the SPA index.html, not actual file contents
         if response.status_code == 200:
             assert "root:" not in response.text
+
+
+class TestCreateSessionErrorMapping:
+    """Regression: OSError from subprocess (e.g. EMFILE) used to surface as a
+    bare 500 'Internal Server Error' with no body. It now maps to 503 with
+    a diagnostic detail so the frontend can show the real cause."""
+
+    def test_oserror_maps_to_503_with_detail(self, client, tmp_path, mocker):
+        mocker.patch(
+            "lumbergh.routers.sessions.create_tmux_session",
+            side_effect=OSError(24, "Too many open files"),
+        )
+
+        response = client.post(
+            "/api/sessions",
+            json={"name": "emfile-test", "workdir": str(tmp_path)},
+        )
+
+        assert response.status_code == 503
+        detail = response.json()["detail"]
+        assert "Too many open files" in detail
+        assert "file-descriptor" in detail
+
+    def test_runtime_error_still_maps_to_500(self, client, tmp_path, mocker):
+        mocker.patch(
+            "lumbergh.routers.sessions.create_tmux_session",
+            side_effect=RuntimeError("tmux session create failed: bad config"),
+        )
+
+        response = client.post(
+            "/api/sessions",
+            json={"name": "runtime-error-test", "workdir": str(tmp_path)},
+        )
+
+        assert response.status_code == 500
+        assert "bad config" in response.json()["detail"]

--- a/backend/lumbergh/tests/test_session_manager.py
+++ b/backend/lumbergh/tests/test_session_manager.py
@@ -1,0 +1,116 @@
+"""Tests for SessionManager — specifically the copy-mode poll cleanup.
+
+Regression: the 250ms copy-mode polling loop used to swallow subprocess
+failures without killing the child, leaking stdout/stderr pipes until the
+backend hit EMFILE. These tests lock down the kill+reap contract.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from lumbergh.session_manager import SessionManager
+
+
+def _make_proc(stdout: bytes = b"", returncode: int | None = None) -> MagicMock:
+    """Build a mock asyncio subprocess. returncode=None means 'still running'."""
+    proc = MagicMock()
+    proc.communicate = AsyncMock(return_value=(stdout, b""))
+    proc.wait = AsyncMock(return_value=0)
+    proc.kill = MagicMock()
+    proc.returncode = returncode
+    return proc
+
+
+async def test_poll_copy_mode_returns_true_when_pane_in_copy_mode(mocker: MockerFixture) -> None:
+    proc = _make_proc(stdout=b"copy-mode\n")
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+
+    result = await SessionManager()._poll_copy_mode("s1")
+
+    assert result is True
+    proc.kill.assert_not_called()
+
+
+async def test_poll_copy_mode_returns_false_for_normal_pane(mocker: MockerFixture) -> None:
+    proc = _make_proc(stdout=b"\n")
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+
+    result = await SessionManager()._poll_copy_mode("s1")
+
+    assert result is False
+    proc.kill.assert_not_called()
+
+
+def _fail_wait_for(exc: BaseException):
+    """wait_for side_effect that closes the awaited coroutine before raising,
+    so AsyncMock-produced coroutines don't linger as un-awaited warnings."""
+
+    async def _raise(coro, timeout):  # noqa: ARG001 — signature must match asyncio.wait_for
+        coro.close()
+        raise exc
+
+    return _raise
+
+
+async def test_poll_copy_mode_reaps_proc_on_timeout(mocker: MockerFixture) -> None:
+    """TimeoutError during communicate() must kill and await the proc so pipes close."""
+    proc = _make_proc(returncode=None)
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+    mocker.patch("asyncio.wait_for", side_effect=_fail_wait_for(TimeoutError()))
+
+    result = await SessionManager()._poll_copy_mode("s1")
+
+    assert result is None
+    proc.kill.assert_called_once()
+    proc.wait.assert_called_once()
+
+
+async def test_poll_copy_mode_reaps_proc_on_oserror(mocker: MockerFixture) -> None:
+    """OSError (e.g. EMFILE) during communicate() must also reap the proc."""
+    proc = _make_proc(returncode=None)
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+    mocker.patch(
+        "asyncio.wait_for",
+        side_effect=_fail_wait_for(OSError(24, "Too many open files")),
+    )
+
+    result = await SessionManager()._poll_copy_mode("s1")
+
+    assert result is None
+    proc.kill.assert_called_once()
+    proc.wait.assert_called_once()
+
+
+async def test_poll_copy_mode_skips_kill_if_proc_already_exited(mocker: MockerFixture) -> None:
+    """If returncode is set, proc has exited — don't try to kill it again."""
+    proc = _make_proc(returncode=0)
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+    mocker.patch("asyncio.wait_for", side_effect=_fail_wait_for(TimeoutError()))
+
+    result = await SessionManager()._poll_copy_mode("s1")
+
+    assert result is None
+    proc.kill.assert_not_called()
+
+
+async def test_poll_copy_mode_returns_none_when_spawn_itself_fails(
+    mocker: MockerFixture,
+) -> None:
+    """If subprocess spawn raises OSError (EMFILE), there's no proc to reap — just bail."""
+    mocker.patch(
+        "asyncio.create_subprocess_exec",
+        side_effect=OSError(24, "Too many open files"),
+    )
+
+    result = await SessionManager()._poll_copy_mode("s1")
+
+    assert result is None
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton() -> None:
+    """SessionManager is a singleton — clear _sessions between tests."""
+    mgr = SessionManager()
+    mgr._sessions.clear()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=4.1",
+    "pytest-mock>=3.12",
     "httpx>=0.27",
     "ruff>=0.3",
     "mypy>=1.8",

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 cd "$(dirname "$0")"
+source "$(dirname "$0")/../scripts/ensure-path.sh"
 uv run uvicorn lumbergh.main:app --host 0.0.0.0 --port 8420 --reload --timeout-graceful-shutdown 3

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -89,7 +89,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3549,7 +3548,6 @@
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3565,7 +3563,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3645,7 +3642,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -3975,7 +3971,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4231,7 +4226,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4590,7 +4584,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -4991,7 +4984,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5563,7 +5555,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9267,7 +9258,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9277,7 +9267,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10448,7 +10437,6 @@
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -10657,7 +10645,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11009,7 +10996,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11460,7 +11446,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11528,7 +11513,6 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -11702,7 +11686,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/components/CreateSessionModal.tsx
+++ b/frontend/src/components/CreateSessionModal.tsx
@@ -16,6 +16,42 @@ interface Props {
 type SessionMode = 'existing' | 'new' | 'worktree'
 type DirStatus = 'unchecked' | 'checking' | 'exists' | 'not_found' | 'error'
 
+async function postSession(
+  body: Record<string, unknown>
+): Promise<{ name: string; existing?: boolean }> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), 15000)
+  let res: Response
+  try {
+    res = await fetch(`${getApiBase()}/sessions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
+  } catch (fetchErr) {
+    if ((fetchErr as Error).name === 'AbortError') {
+      throw new Error('Request timed out after 15s — the backend may be unresponsive.')
+    }
+    throw fetchErr
+  } finally {
+    clearTimeout(timeoutId)
+  }
+
+  if (!res.ok) {
+    let detail = `Server returned ${res.status}`
+    try {
+      const data = await res.json()
+      if (data.detail) detail = data.detail
+    } catch {
+      const text = await res.text().catch(() => '')
+      if (text) detail = text
+    }
+    throw new Error(detail)
+  }
+  return res.json()
+}
+
 // Generate a URL-safe slug from free-form text
 function toSlug(text: string): string {
   return text
@@ -180,18 +216,7 @@ export default function CreateSessionModal({ onClose, onCreated }: Props) {
         }
       }
 
-      const res = await fetch(`${getApiBase()}/sessions`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      })
-
-      if (!res.ok) {
-        const data = await res.json()
-        throw new Error(data.detail || 'Failed to create session')
-      }
-
-      const data = await res.json()
+      const data = await postSession(body)
       if (data.existing) {
         navigate(`/session/${data.name}`)
         onClose()

--- a/frontend/src/components/DirectoryPicker.tsx
+++ b/frontend/src/components/DirectoryPicker.tsx
@@ -12,6 +12,22 @@ interface Props {
   onManualEntry?: () => void
 }
 
+function EmptyResults({ query, looksLikePath }: { query: string; looksLikePath: boolean }) {
+  let message: string
+  if (!query) {
+    message = 'No repositories found in the configured search directory'
+  } else if (looksLikePath) {
+    message = `Path does not exist: ${query}`
+  } else {
+    message = 'No matching repositories found'
+  }
+  return (
+    <div className="px-3 py-2 text-sm">
+      <div className="text-text-tertiary">{message}</div>
+    </div>
+  )
+}
+
 export default function DirectoryPicker({ value, onChange, onManualEntry }: Props) {
   const [query, setQuery] = useState('')
   const [directories, setDirectories] = useState<Directory[]>([])
@@ -24,20 +40,33 @@ export default function DirectoryPicker({ value, onChange, onManualEntry }: Prop
   const dropdownRef = useRef<HTMLDivElement>(null)
   const debounceRef = useRef<number | null>(null)
 
-  // Fetch directories based on query
+  // Fetch directories based on query. For absolute/home paths, skip the repo
+  // search and validate the path directly so the user can pick anything on disk.
   const fetchDirectories = useCallback(async (searchQuery: string) => {
     setIsLoading(true)
     setError(null)
 
+    const isAbsolute = searchQuery.startsWith('/') || searchQuery.startsWith('~')
+    const endpoint = isAbsolute
+      ? `${getApiBase()}/directories/validate?path=${encodeURIComponent(searchQuery.trim())}`
+      : `${getApiBase()}/directories/search?query=${encodeURIComponent(searchQuery)}`
+
     try {
-      const res = await fetch(
-        `${getApiBase()}/directories/search?query=${encodeURIComponent(searchQuery)}`
-      )
+      const res = await fetch(endpoint)
       if (!res.ok) {
         throw new Error('Failed to fetch directories')
       }
       const data = await res.json()
-      setDirectories(data.directories || [])
+      if (isAbsolute) {
+        const resolved: string = data.path || searchQuery
+        setDirectories(
+          data.exists
+            ? [{ path: resolved, name: resolved.split('/').filter(Boolean).pop() || resolved }]
+            : []
+        )
+      } else {
+        setDirectories(data.directories || [])
+      }
       setHighlightedIndex(0)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Search failed')
@@ -93,6 +122,8 @@ export default function DirectoryPicker({ value, onChange, onManualEntry }: Prop
     setQuery('')
     setIsOpen(false)
   }
+
+  const looksLikePath = query.startsWith('/') || query.startsWith('~')
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (!isOpen) {
@@ -207,11 +238,7 @@ export default function DirectoryPicker({ value, onChange, onManualEntry }: Prop
           {error ? (
             <div className="px-3 py-2 text-red-400 text-sm">{error}</div>
           ) : directories.length === 0 && !isLoading ? (
-            <div className="px-3 py-2 text-text-tertiary text-sm">
-              {query
-                ? 'No matching repositories found'
-                : 'No repositories found in the configured search directory'}
-            </div>
+            <EmptyResults query={query} looksLikePath={looksLikePath} />
           ) : (
             directories.map((dir, index) => (
               <button

--- a/frontend/start.sh
+++ b/frontend/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 cd "$(dirname "$0")"
+source "$(dirname "$0")/../scripts/ensure-path.sh"
 source "$(dirname "$0")/../scripts/check-node.sh"
 npm install
 npm run dev

--- a/scripts/check-node.sh
+++ b/scripts/check-node.sh
@@ -7,10 +7,23 @@ REQUIRED_MINOR=19
 REQUIRED_PATCH=0
 
 if ! command -v node &>/dev/null; then
-    echo "Error: Node.js is not installed."
+    echo "Error: 'node' not found on PATH."
+    echo "  PATH=$PATH"
+    echo "  If node is installed (e.g. 'which node' works in your shell), your"
+    echo "  login shell config likely isn't loading in this (non-interactive) context."
     echo "  Recommended: install via nvm (Node Version Manager)"
     echo "  Install nvm: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash"
     echo "  Then: nvm install --lts"
+    exit 1
+fi
+
+if ! command -v npm &>/dev/null; then
+    echo "Error: 'npm' not found on PATH (but 'node' was found at: $(command -v node))."
+    echo "  PATH=$PATH"
+    echo "  npm usually ships with node. If 'which npm' works in your interactive"
+    echo "  shell but fails here, your shell config (e.g. ~/.config/fish/config.fish)"
+    echo "  is adding npm's directory only for interactive sessions. Move the PATH"
+    echo "  setup out of the interactive-only block so non-interactive scripts see it."
     exit 1
 fi
 

--- a/scripts/ensure-path.sh
+++ b/scripts/ensure-path.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Prepend platform-standard bin dirs to PATH so scripts invoked from tmux/send-keys
+# (which can race against interactive shell init on some setups) still find common
+# tools like npm, node, uv.
+case "$(uname -s)" in
+    Darwin)
+        export PATH="/opt/homebrew/bin:/usr/local/bin:$HOME/.local/bin:$PATH"
+        ;;
+    Linux)
+        export PATH="/usr/local/bin:/usr/bin:$HOME/.local/bin:$PATH"
+        ;;
+esac

--- a/test/e2e-ui/features/dashboard_extended.feature
+++ b/test/e2e-ui/features/dashboard_extended.feature
@@ -13,6 +13,24 @@ Feature: Dashboard Extended
     And I enter session name "e2e-validation-test" in the create modal
     Then the create button should be disabled or show directory not found
 
+  Scenario: Create session by typing an absolute path into the search
+    Given I am on the dashboard
+    When I click the new session button
+    And I type the test-repo-2 absolute path into the directory search
+    Then the typed path should appear as a selectable result
+    When I select the typed path result
+    And I enter session name "e2e-abs-path" in the create modal
+    And I submit the create session form
+    Then I should be on the session page for "e2e-abs-path"
+    And the "e2e-abs-path" session is cleaned up
+
+  Scenario: Typing a nonexistent absolute path shows an error
+    Given I am on the dashboard
+    When I click the new session button
+    And I type absolute path "/nonexistent/path/e2e-abs-missing" into the directory search
+    Then the directory search should show a path-does-not-exist error
+    And the create button should be disabled
+
   Scenario: Dashboard is usable on mobile viewport
     Given I am on the dashboard with mobile viewport
     And a test session exists

--- a/test/e2e-ui/test_dashboard_extended.py
+++ b/test/e2e-ui/test_dashboard_extended.py
@@ -82,6 +82,53 @@ def create_button_disabled_or_not_found(page: Page):
     )
 
 
+@when("I type the test-repo-2 absolute path into the directory search")
+def type_absolute_path_search(page: Page, repo_dir: str):
+    # DirectoryPicker's search input has no data-testid; locate by placeholder.
+    search = page.get_by_placeholder("Search git repositories...")
+    search.fill(f"{repo_dir}/test-repo-2")
+    # Picker debounces the validate call at 300ms — wait for the result row.
+    page.wait_for_timeout(600)
+
+
+@when(parsers.parse('I type absolute path "{path}" into the directory search'))
+def type_custom_absolute_path(page: Page, path: str):
+    search = page.get_by_placeholder("Search git repositories...")
+    search.fill(path)
+    page.wait_for_timeout(600)
+
+
+@then("the typed path should appear as a selectable result")
+def typed_path_appears(page: Page, repo_dir: str):
+    expected_path = f"{repo_dir}/test-repo-2"
+    # The dropdown entry renders the path as monospace subtext.
+    entry = page.get_by_text(expected_path, exact=True)
+    expect(entry).to_be_visible(timeout=5000)
+
+
+@when("I select the typed path result")
+def select_typed_path(page: Page, repo_dir: str):
+    expected_path = f"{repo_dir}/test-repo-2"
+    page.get_by_text(expected_path, exact=True).click()
+
+
+@then("the directory search should show a path-does-not-exist error")
+def path_missing_error(page: Page):
+    expect(page.get_by_text("Path does not exist:", exact=False)).to_be_visible(timeout=5000)
+
+
+@then("the create button should be disabled")
+def create_button_disabled(page: Page):
+    btn = page.locator('[data-testid="create-session-submit"]')
+    expect(btn).to_be_disabled()
+
+
+@then(parsers.parse('the "{name}" session is cleaned up'))
+def cleanup_created_session(base_url: str, name: str):
+    with httpx.Client(base_url=base_url, timeout=10.0) as client:
+        client.delete(f"/api/sessions/{name}")
+
+
 @given("I am on the dashboard with mobile viewport")
 def go_to_dashboard_mobile(page: Page, base_url: str):
     """Resize the existing page to a mobile viewport (iPhone-sized) and navigate."""


### PR DESCRIPTION
Creating a session at a path outside the configured repo search directory left the UI wedged with no error, and a long-running backend would eventually return an empty 500 on the same request. Digging in turned up three unrelated problems that combined into that one-bad-experience report, so they are bundled here.

The copy-mode poll loop in `SessionManager` spawns a tmux subprocess every 250ms per connected session. Its `except` clause swallowed every failure with a bare `continue`, which left the child's stdout/stderr pipes open on any timeout or `OSError`. Under load this drained the backend's file-descriptor budget until new spawns hit `EMFILE` — including the one inside `create_session`. The poll loop now catches specific exceptions and explicitly kills and reaps the child so the pipes close. 🔧

When `create_session` did hit `EMFILE`, it raised `OSError` out of a handler that only caught `RuntimeError`, so FastAPI returned a bare `500`. It now maps `OSError` to `503` with the exception text and a hint about the fd limit, giving the client an actual cause to render.

`DirectoryPicker` only searched `repoSearchDir`, which defaults to `$HOME` when the backend is launched via `start.sh` (the `LUMBERGH_LAUNCH_DIR` hook in `cli.py` is bypassed). Any path outside that root was unreachable from the UI. The picker now detects absolute and `~`-prefixed queries, validates them directly, and presents the typed path as a selectable result when it exists or a clear `Path does not exist` message when it doesn't. `CreateSessionModal` also gained a 15s `AbortController` timeout and a text fallback for non-JSON error bodies, so a hung or misbehaving backend can no longer leave the submit button disabled with no feedback. ✨

Separately, `bootstrap.sh` races fish's interactive init: `send-keys` fires before `/opt/homebrew/bin` lands on `PATH`, so `start.sh` failed with `npm: command not found` even though the tool was installed. The start scripts now source a small `scripts/ensure-path.sh` that prepends platform-standard bin dirs, and `check-node.sh` dumps `PATH` on failure so the next variant of this is easier to diagnose.

Reviewers: the `sessions.py` router now uses `http.HTTPStatus` for its new raises while the rest of the file still uses raw ints. Intentional per an existing preference to not mass-refactor, but happy to flip either way.