### PR TITLE
fix(terminal): treat Ctrl+V as paste so clipboard-injection tools work

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -289,9 +289,42 @@ export default memo(function Terminal({
     // xterm.js's _keyPress handler from also sending \r (carriage return/submit).
     // When the custom handler blocks only keydown, xterm.js doesn't call preventDefault(),
     // so the browser fires keypress which leaks through and sends \r to the terminal.
+    // Ctrl+V / Cmd+V (without Shift): treat as paste so clipboard-injection
+    // tools like Wispr Flow work. xterm.js would otherwise send literal ^V
+    // to the PTY, since browsers reserve Ctrl+Shift+V for terminal paste.
+    // Use Ctrl+Alt+V as the escape hatch to send a literal ^V byte.
+    const isPasteShortcut = (event: KeyboardEvent) =>
+      event.type === 'keydown' &&
+      (event.ctrlKey || event.metaKey) &&
+      !event.shiftKey &&
+      !event.altKey &&
+      (event.key === 'v' || event.key === 'V')
+
+    const handlePasteShortcut = () => {
+      navigator.clipboard
+        .readText()
+        .then((text) => {
+          if (!text) return
+          const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+          if (normalized.includes('\n')) {
+            sendViaApi(normalized, false)
+          } else {
+            sendRef.current(normalized)
+          }
+        })
+        .catch(() => {
+          // Clipboard read denied (insecure context or permission) — silently ignore
+        })
+    }
+
     term.attachCustomKeyEventHandler((event) => {
       // Ctrl+[ / Ctrl+] cycles sessions — let the window handler deal with it
       if (event.ctrlKey && (event.key === '[' || event.key === ']')) {
+        return false
+      }
+      if (isPasteShortcut(event)) {
+        event.preventDefault()
+        handlePasteShortcut()
         return false
       }
       if (event.key === 'Enter' && event.shiftKey) {


### PR DESCRIPTION
## Problem

Dictation and clipboard-injection tools like [Wispr Flow](https://wisprflow.ai/), Talon, AutoHotKey macros, and many accessibility tools paste text by writing to the system clipboard and then simulating a **Ctrl+V** keystroke. Inside a Lumbergh terminal pane these tools currently appear to do nothing — the dictated text never lands.

The reason is standard xterm.js / browser-terminal behavior: **Ctrl+V** in a terminal sends the literal `^V` byte to the PTY, while browsers reserve **Ctrl+Shift+V** as the shortcut that fires a real `paste` clipboard event. Tools that simulate plain Ctrl+V can't reach the existing paste handler.

## Fix

Intercept Ctrl/Cmd+V (without Shift) in the existing `attachCustomKeyEventHandler`, read the clipboard with `navigator.clipboard.readText()`, and forward the contents through the same send path the terminal already uses for typed input (multiline goes through `sendViaApi`, single-line via raw `send`).

Ctrl+Shift+V continues to work exactly as before. **Ctrl+Alt+V** is preserved as the escape hatch for sending a literal `^V` byte to the PTY (xterm passes that combo through unchanged), so the only "lost" capability is sending `^V` via the unmodified Ctrl+V — which Claude Code and most TUIs do not need.

## Tradeoffs

- ✅ Wispr Flow / Talon / AutoHotKey-style dictation tools now paste into the terminal.
- ✅ Normal Ctrl+V paste from any source works without the extra Shift modifier.
- ✅ Ctrl+Shift+V unchanged.
- ⚠️ Ctrl+V no longer sends a literal `^V` to the PTY. Use Ctrl+Alt+V if needed.
- ℹ️ `clipboard.readText()` requires a secure context (https or localhost), which Lumbergh already runs in. Permission failures fall through silently.

## Test plan

- [x] Lint + typecheck (`./lint.sh`) passes
- [x] Wispr Flow dictation pastes into terminal (verified by author)
- [ ] Ctrl+V (plain) pastes single-line clipboard content
- [ ] Ctrl+V (plain) pastes multiline clipboard content via the bracketed-paste route
- [ ] Ctrl+Shift+V still works
- [ ] Ctrl+Alt+V still sends literal `^V`