### PR TITLE
feat(contrib): add systemd unit and env-file recipe for self-hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ data/
 # Lumbergh package build artifacts
 backend/lumbergh/frontend_dist/
 !backend/lumbergh/frontend_dist/.gitkeep
+
+# Working artifact for /bpe:commit-message
+commit-msg.md

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,101 @@
+# contrib
+
+Community-maintained packaging and deployment helpers for lumbergh. Nothing in
+here is required to run lumbergh — these are recipes for common deployment
+shapes.
+
+## `systemd/` — running lumbergh as a service
+
+Two files:
+
+| File | Purpose |
+|------|---------|
+| `lumbergh.service` | Template systemd unit. Installed as `/etc/systemd/system/lumbergh@.service` and instantiated per user (e.g. `lumbergh@mmegger.service`). |
+| `lumbergh.env.example` | Annotated reference of every supported environment variable and CLI flag. Copy to `/etc/default/lumbergh`. |
+
+### Prerequisites
+
+- `tmux` and `git` on `PATH` for the target user.
+- `lumbergh` installed for the target user (e.g. `uv tool install pylumbergh`,
+  which symlinks the binary into `~/.local/bin`).
+- Tailscale up — **only** if you plan to use `--tailscale-only`.
+
+### Install
+
+```bash
+sudo cp contrib/systemd/lumbergh.service /etc/systemd/system/lumbergh@.service
+sudo cp contrib/systemd/lumbergh.env.example /etc/default/lumbergh   # optional
+sudo systemctl daemon-reload
+sudo systemctl enable --now lumbergh@<your-username>.service
+```
+
+Replace `<your-username>` with the Linux user that owns `~/.config/lumbergh/`
+and the tmux sessions you want to supervise. The unit is a template (note the
+`@` in the filename), so the username becomes the instance — that's what
+`%i` expands to inside the unit.
+
+### Why a template unit?
+
+Templates let one unit file serve any number of users on a host without
+edits. If you only ever have one user, treat `lumbergh@mmegger` as the unit
+name and move on — there is no functional downside.
+
+### Configuring startup flags
+
+Default install binds lumbergh to `0.0.0.0:8420`. To change that, edit
+`/etc/default/lumbergh` and uncomment options in `LUMBERGH_ARGS`:
+
+```bash
+sudo $EDITOR /etc/default/lumbergh
+sudo systemctl restart lumbergh@<your-username>.service
+```
+
+Common combinations are in the example file. The whole file is one big
+discoverable reference — read through it to see what's available.
+
+### Day-to-day operations
+
+```bash
+systemctl status lumbergh@<your-username>.service
+systemctl restart lumbergh@<your-username>.service
+systemctl stop lumbergh@<your-username>.service
+journalctl -u lumbergh@<your-username>.service -f         # follow logs
+systemctl show -p Environment lumbergh@<your-username>.service   # see loaded env
+```
+
+The startup log line tells you what's actually bound:
+
+- `Uvicorn running on http://100.x.x.x:8420` → `--tailscale-only` is in effect.
+- `Uvicorn running on http://0.0.0.0:8420` → not bound to tailscale.
+
+### Gotchas
+
+- **Auth.** Without `LUMBERGH_PASSWORD` (or a password set in Settings →
+  Security), anyone who can reach the bind address can use the dashboard.
+  Pair `--tailscale-only` with auth in any setup that matters.
+- **`LUMBERGH_LAUNCH_DIR`** in the env file does nothing — lumbergh
+  overwrites it from the process CWD at startup. Set
+  `WorkingDirectory=` in the unit instead, or override the search dir in
+  the Settings UI.
+- **tmux socket sharing.** The unit deliberately omits `PrivateTmp=` so the
+  service shares `/tmp/tmux-<uid>` with your interactive shells. Don't add
+  it back unless you want lumbergh blind to sessions you start by hand.
+- **`$HOME` is writable.** The unit deliberately omits `ProtectHome=`
+  because lumbergh supervises agents that edit code throughout your home.
+  If you sandbox `$HOME`, the whole tool stops working.
+- **Tailscale ordering.** The unit has `After=tailscaled.service` /
+  `Wants=tailscaled.service` but **not** `Requires=`, so the service is
+  fine on hosts without Tailscale. If you set `--tailscale-only` on such
+  a host, lumbergh exits at startup with a clear error.
+
+### Uninstall
+
+```bash
+sudo systemctl disable --now lumbergh@<your-username>.service
+sudo rm /etc/systemd/system/lumbergh@.service
+sudo rm -f /etc/default/lumbergh
+sudo systemctl daemon-reload
+```
+
+Data in `~/.config/lumbergh/` is left in place — remove it manually if you
+want a clean slate.

--- a/contrib/systemd/lumbergh.env.example
+++ b/contrib/systemd/lumbergh.env.example
@@ -1,0 +1,60 @@
+# Environment file for lumbergh.service.
+#
+# Install:
+#   sudo cp contrib/systemd/lumbergh.env.example /etc/default/lumbergh
+#   sudo systemctl restart lumbergh@<user>.service
+#
+# All options below are commented out — uncomment only what you need.
+# Format is KEY=VALUE (one per line, no quotes needed for simple values).
+# Restart the service after every edit.
+
+
+# ---------------------------------------------------------------------------
+# CLI flags
+# ---------------------------------------------------------------------------
+# Everything in $LUMBERGH_ARGS is appended to the lumbergh command line.
+# Only one LUMBERGH_ARGS= line takes effect — combine flags on a single line.
+
+# Bind only to the Tailscale interface (rejects non-Tailscale traffic).
+# Requires tailscale to be installed and connected; the service will exit
+# at startup otherwise.
+#LUMBERGH_ARGS=--tailscale-only
+
+# Bind to a specific host instead of the default 0.0.0.0. Useful when
+# fronting lumbergh with Caddy/nginx/Cloudflare for TLS termination.
+#LUMBERGH_ARGS=--host 127.0.0.1
+
+# Bind to a non-default port (default: 8420).
+#LUMBERGH_ARGS=-p 9000
+
+# Flags can be combined on one line:
+#LUMBERGH_ARGS=--tailscale-only -p 9000
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+# Dashboard password. Without it, anyone who can reach the bind address
+# can use the dashboard. Equivalent to Settings → Security → Password in
+# the UI. Leave commented to disable auth entirely.
+#LUMBERGH_PASSWORD=changeme
+
+
+# ---------------------------------------------------------------------------
+# Data storage
+# ---------------------------------------------------------------------------
+
+# Where lumbergh keeps sessions, todos, prompts, shared files, and settings.
+# Default: ~/.config/lumbergh/. The target user must own this directory.
+#LUMBERGH_DATA_DIR=/var/lib/lumbergh
+
+
+# ---------------------------------------------------------------------------
+# Notes
+# ---------------------------------------------------------------------------
+# LUMBERGH_LAUNCH_DIR (the default repo-search directory shown in the
+# dashboard) cannot be set here — lumbergh overwrites it from the process
+# CWD at startup (see cli.py:79). To change it, edit WorkingDirectory= in
+# /etc/systemd/system/lumbergh@.service, or set "Repository search directory"
+# in the Settings UI to override per-installation.

--- a/contrib/systemd/lumbergh.service
+++ b/contrib/systemd/lumbergh.service
@@ -1,0 +1,52 @@
+# systemd service unit for lumbergh. Runs as the unprivileged %i user.
+#
+# Install:
+#   sudo cp contrib/systemd/lumbergh.service /etc/systemd/system/lumbergh@.service
+#   sudo cp contrib/systemd/lumbergh.env.example /etc/default/lumbergh   # optional
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now lumbergh@<your-username>.service
+#
+# Out of the box this binds lumbergh to 0.0.0.0:8420. To restrict it to your
+# Tailscale interface (or pass any other CLI flag), edit /etc/default/lumbergh
+# and set LUMBERGH_ARGS=--tailscale-only — see lumbergh.env.example.
+#
+# Logs:    journalctl -u lumbergh@<your-username>.service -f
+# Data:    ~<user>/.config/lumbergh/ (override with LUMBERGH_DATA_DIR=)
+#
+# Requires `lumbergh` on PATH for the target user (e.g. via `uv tool install
+# pylumbergh`, which symlinks into ~/.local/bin), plus tmux and git. Tailscale
+# is only needed if you pass --tailscale-only.
+
+[Unit]
+Description=Lumbergh AI session supervisor (user %i)
+Documentation=https://voglster.github.io/lumbergh/
+After=network-online.target tailscaled.service
+Wants=network-online.target tailscaled.service
+
+[Service]
+Type=simple
+User=%i
+Group=%i
+WorkingDirectory=/home/%i
+Environment=PATH=/home/%i/.local/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-/etc/default/lumbergh
+ExecStart=/home/%i/.local/bin/lumbergh $LUMBERGH_ARGS
+Restart=on-failure
+RestartSec=5
+KillSignal=SIGINT
+TimeoutStopSec=15
+
+# Hardening. Lumbergh needs to write project files throughout $HOME (it
+# supervises agents that edit code) and must share /tmp with the user's
+# interactive shells so tmux sockets at /tmp/tmux-<uid> are visible, so
+# ProtectHome and PrivateTmp are deliberately left off.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds `contrib/systemd/lumbergh.service` (per-user template unit), `contrib/systemd/lumbergh.env.example` (annotated reference of every supported env var and CLI flag), and `contrib/README.md` (install + day-to-day ops + gotchas).
- Out of the box the service binds `0.0.0.0:8420`; operators toggle `--tailscale-only`, port, host, auth password, and data dir by editing `/etc/default/lumbergh` and restarting.
- Hardening is deliberately loose on `ProtectHome=` and `PrivateTmp=` because lumbergh writes project files throughout `$HOME` and needs to share `/tmp/tmux-<uid>` sockets with the user's interactive shells. The README documents both choices.

The docs cover installation but stop short of running lumbergh as a boot-time service today, so every operator ends up rolling their own unit. This is the recipe I ended up with on my own server — happy to iterate on the shape if you'd rather have it live somewhere other than `contrib/`, or split differently.

## Test plan

- [x] Installed `lumbergh@.service` from this branch on a Linux host (Tailscale + uv-installed `pylumbergh`).
- [x] `systemctl enable --now lumbergh@<user>.service` → `Active: active (running)`, journal shows `Uvicorn running on http://<tailscale-ip>:8420`.
- [x] `systemd-analyze verify lumbergh@<user>.service` passes clean against an instantiated template.
- [x] Toggled `LUMBERGH_ARGS=--tailscale-only` on/off in `/etc/default/lumbergh`; restart switches the bind address as expected.
- [ ] Not tested: psmux/Windows path (unit is Linux-only by design).