### PR TITLE
fix(self-hosting): unbreak v0.17.0 — revert %h in systemd unit, set TERM in PTY child

### DIFF
--- a/backend/lumbergh/tests/test_tmux_pty.py
+++ b/backend/lumbergh/tests/test_tmux_pty.py
@@ -1,4 +1,6 @@
-"""Tests for tmux PTY I/O — short-write handling on large pastes."""
+"""Tests for tmux PTY I/O — short-write handling and child-exec env setup."""
+
+import os
 
 from fastapi import WebSocketDisconnect
 
@@ -42,3 +44,44 @@ async def test_write_loop_handles_short_writes(monkeypatch):
 
     assert bytes(written) == payload.encode("utf-8")
     assert call_count[0] >= 2, "expected retry after short write"
+
+
+def test_exec_tmux_attach_sets_term_when_unset(monkeypatch):
+    """Regression: daemon-launched parents (systemd, docker, cron) have no
+    TERM in env. Without one, tmux exits at startup with `open terminal
+    failed: terminal does not support clear`. The child must set TERM
+    before exec'ing tmux.
+    """
+    monkeypatch.delenv("TERM", raising=False)
+
+    captured: dict[str, object] = {}
+
+    def fake_execlp(*args):
+        captured["args"] = args
+        captured["TERM"] = os.environ.get("TERM")
+
+    monkeypatch.setattr(tmux_pty.os, "execlp", fake_execlp)
+
+    tmux_pty._exec_tmux_attach("mysession")
+
+    assert captured["TERM"] == "xterm-256color"
+    assert captured["args"][-1] == "mysession"
+
+
+def test_exec_tmux_attach_preserves_explicit_term(monkeypatch):
+    """Operators running custom xterm.js builds (or different terminfo)
+    must be able to override TERM via the inherited environment.
+    setdefault — not assignment — keeps that escape hatch open.
+    """
+    monkeypatch.setenv("TERM", "screen-256color")
+
+    captured: dict[str, object] = {}
+
+    def fake_execlp(*_args):
+        captured["TERM"] = os.environ.get("TERM")
+
+    monkeypatch.setattr(tmux_pty.os, "execlp", fake_execlp)
+
+    tmux_pty._exec_tmux_attach("mysession")
+
+    assert captured["TERM"] == "screen-256color"

--- a/backend/lumbergh/tmux_pty.py
+++ b/backend/lumbergh/tmux_pty.py
@@ -199,6 +199,25 @@ def _session_exists(session_name: str) -> bool:
     return False
 
 
+def _exec_tmux_attach(session_name: str) -> None:
+    """Replace the current (forked child) process with `tmux attach-session`.
+
+    Sets TERM if unset so tmux can initialize a terminfo entry. Without this,
+    daemon-launched parents (systemd, docker, cron, supervisord) inherit no
+    TERM and tmux exits at startup with
+    `open terminal failed: terminal does not support clear`. setdefault
+    preserves any explicit TERM the operator passes in.
+    """
+    os.environ.setdefault("TERM", "xterm-256color")
+    os.execlp(
+        TMUX_CMD,
+        TMUX_CMD,
+        "attach-session",
+        "-t",
+        session_name,
+    )
+
+
 class TmuxPtySession:
     """Manages a PTY connected to a tmux/psmux session for bidirectional I/O.
 
@@ -230,13 +249,7 @@ class TmuxPtySession:
 
         if pid == 0:
             # Child process - exec tmux attach
-            os.execlp(
-                TMUX_CMD,
-                TMUX_CMD,
-                "attach-session",
-                "-t",
-                self.session_name,
-            )
+            _exec_tmux_attach(self.session_name)
         else:
             self.pid = pid
             self.master_fd = fd

--- a/contrib/systemd/lumbergh.service
+++ b/contrib/systemd/lumbergh.service
@@ -27,10 +27,10 @@ Wants=network-online.target tailscaled.service
 Type=simple
 User=%i
 Group=%i
-WorkingDirectory=%h
-Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+WorkingDirectory=/home/%i
+Environment=PATH=/home/%i/.local/bin:/usr/local/bin:/usr/bin:/bin
 EnvironmentFile=-/etc/default/lumbergh
-ExecStart=%h/.local/bin/lumbergh $LUMBERGH_ARGS
+ExecStart=/home/%i/.local/bin/lumbergh $LUMBERGH_ARGS
 Restart=on-failure
 RestartSec=5
 KillSignal=SIGINT


### PR DESCRIPTION
Fixes #23.

## Summary

Commit c409793 (`fix(contrib/systemd): drop personal gitignore entry, use %h for home`) swapped `/home/%i` for `%h` in `WorkingDirectory`, the `PATH` `Environment=` line, and `ExecStart`. That breaks every install that follows this unit's own README, because the unit is enabled under the **system** manager (`WantedBy=multi-user.target`, copied to `/etc/systemd/system/`), not the per-user manager.

## Why `%h` is wrong here

Per [`systemd.unit(5)`](https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Specifiers):

> `%h` — User home directory. This is the home directory of the user running the service manager instance. **In case of the system manager this resolves to `/root`.**

Specifiers are expanded at unit-load time against the manager — they do **not** look at `User=`. So for `lumbergh@mmegger.service` started by PID 1:

| Directive | After expansion |
|---|---|
| `WorkingDirectory=%h` | `/root` |
| `Environment=PATH=%h/.local/bin:...` | `/root/.local/bin:...` |
| `ExecStart=%h/.local/bin/lumbergh` | `/root/.local/bin/lumbergh` |

Observed failure on a fresh install (current `main`):

```
systemd[1]: lumbergh@mmegger.service: Failed to locate executable
            /root/.local/bin/lumbergh: No such file or directory
systemd[1]: lumbergh@mmegger.service: Main process exited,
            code=exited, status=203/EXEC
systemd[1]: lumbergh@mmegger.service: Failed with result 'exit-code'.
```

## The fix

Revert the three substitutions to `/home/%i`. `%i` (the instance name — the username after the `@`) is the one specifier tied to the unit's target user regardless of which manager started it.

Yes, hardcoding `/home/` assumes the distro default, but every install path documented in this unit (`~/.local/bin`, `~/.config/lumbergh/`) already assumes the same; users with a non-default home will need a drop-in override either way.

## If `%h` semantics are wanted later

The unit would need to be redesigned as a `--user` service: installed under `~/.config/systemd/user/` and enabled with `systemctl --user enable --now lumbergh.service`. At that point the `@` template and `User=`/`Group=` directives go away, and `%h` resolves correctly because the per-user manager is the one expanding it.

## Test plan

- [x] Reproduce: install current `main`'s unit → `status=203/EXEC`, `ExecStart=/root/.local/bin/lumbergh`
- [x] Apply this patch → service reaches `active (running)`, `Uvicorn running on http://<tailnet-ip>:8420`, `GET /api/sessions` returns `200`
- [ ] Reviewer sanity-check on a non-`/home`-based distro if you want to confirm the doc note about override files

Refs: c409793
