### PR TITLE
fix(terminal): only take over the wheel for mouse-mode panes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,21 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
 
+  frontend-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npm test
+
   frontend-build:
     runs-on: ubuntu-latest
     defaults:

--- a/backend/lumbergh/session_manager.py
+++ b/backend/lumbergh/session_manager.py
@@ -29,6 +29,94 @@ class TerminalClient(Protocol):
     async def send_json(self, data: dict) -> None: ...
 
 
+# tmux tells us what the pane's foreground app is doing. The three mouse flags
+# mean "this app asked for mouse reporting" - exactly when tmux forwards wheel
+# reports to the app instead of scrolling its own history. `|` separates the
+# mode from the flags because pane_mode can be empty.
+_PANE_STATE_FORMAT = "#{pane_mode}|#{mouse_any_flag}#{mouse_button_flag}#{mouse_standard_flag}"
+
+# How often the monitor samples pane state. Quick enough that entering copy mode
+# or launching a fullscreen TUI feels instant, slow enough that the tmux probe
+# stays cheap. Tests shorten it rather than faking asyncio.sleep.
+_PANE_POLL_INTERVAL = 0.25
+
+
+@dataclass(frozen=True)
+class PaneState:
+    """Pane state sampled from tmux, broadcast to terminal WebSocket clients."""
+
+    copy_mode: bool
+    # True for fullscreen mouse-mode TUIs (Claude Code). Such panes need
+    # PageUp/PageDown to scroll; every other pane must keep native wheel ->
+    # xterm mouse report -> tmux copy-mode scrolling.
+    mouse_app: bool
+
+
+def _pane_state_message(state: PaneState) -> dict:
+    """Build the wire message for a pane state.
+
+    The type stays ``copy_mode`` and the copy-mode field stays ``active`` so a
+    stale service-worker-cached frontend ignores the extra key instead of
+    breaking. Kept in one place so that wart can't spread.
+    """
+    return {"type": "copy_mode", "active": state.copy_mode, "mouse_app": state.mouse_app}
+
+
+def _parse_pane_state(raw: str) -> PaneState:
+    """Parse ``_PANE_STATE_FORMAT`` output.
+
+    A tmux that does not know a format variable emits nothing for it, so an
+    unparseable line degrades to "not a mouse app" - the safe native path.
+    """
+    mode, _, mouse_flags = raw.strip().partition("|")
+    return PaneState(copy_mode=mode == "copy-mode", mouse_app="1" in mouse_flags)
+
+
+async def _cancel_task(task: asyncio.Task, label: str, session_name: str) -> None:
+    """Cancel a background task and absorb however it ended.
+
+    A task that already died with a real exception re-raises it here on await.
+    Letting that escape would skip the caller's remaining teardown - the PTY
+    close and the ``_sessions`` removal - leaving a leaked PTY cached under the
+    session name and handed out to every later client.
+    """
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        # Full traceback: this fires at most once per teardown, and a task that
+        # died on its own is the one thing worth diagnosing here.
+        logger.exception(f"{label} for {session_name} ended in error")
+
+
+async def _kill_and_reap(proc: asyncio.subprocess.Process | None) -> None:
+    """Kill a still-running probe subprocess and await it so its pipes close.
+
+    A no-op once the child has exited - a completed ``communicate()`` has
+    already reaped it, which is why callers can run this unconditionally.
+
+    Best-effort, and that is load-bearing: callers run this while an exception is
+    already propagating, so anything raising here would replace it and kill the
+    monitor task. Hence both steps swallow errors, and a kill that fails still
+    falls through to the wait.
+    """
+    if proc is None or proc.returncode is not None:
+        return
+    try:
+        proc.kill()
+    except OSError:
+        # Broad on purpose - see above. ProcessLookupError (child already gone)
+        # is the expected one; a kill we simply can't perform must not become
+        # the monitor's problem either, and wait() below still runs regardless.
+        pass
+    try:
+        await proc.wait()
+    except Exception:  # noqa: S110 - best-effort reap
+        pass
+
+
 @dataclass
 class ManagedSession:
     """A PTY session with multiple connected WebSocket clients."""
@@ -36,7 +124,12 @@ class ManagedSession:
     pty: TmuxPtySession
     clients: set[TerminalClient] = field(default_factory=set)
     read_task: asyncio.Task | None = None
-    copy_mode_task: asyncio.Task | None = None
+    pane_state_task: asyncio.Task | None = None
+    # Last pane state broadcast by the monitor. Lives on the session (not in the
+    # monitor coroutine) because the monitor is created once per PTY: a client
+    # joining a pooled session needs the current state replayed to it, since the
+    # monitor's change-detection has nothing new to announce.
+    pane_state: PaneState | None = None
     # "Latest active device wins" sizing. A tmux window has one size for every
     # client, so when the same session is open on e.g. a phone and a desktop we
     # can't show both at their native size at once. Instead the most recently
@@ -136,9 +229,11 @@ class SessionManager:
                 managed = ManagedSession(pty=pty)
                 self._sessions[session_name] = managed
 
-                # Start the read loop and copy-mode monitor tasks
+                # Start the read loop and pane-state monitor tasks
                 managed.read_task = asyncio.create_task(self._broadcast_loop(session_name))
-                managed.copy_mode_task = asyncio.create_task(self._copy_mode_monitor(session_name))
+                managed.pane_state_task = asyncio.create_task(
+                    self._pane_state_monitor(session_name)
+                )
             else:
                 logger.info(f"Reusing existing PTY for session: {session_name}")
                 managed = self._sessions[session_name]
@@ -156,6 +251,19 @@ class SessionManager:
         # status bar/borders — the source of the "missing decorations" repaint).
         if not is_new_pty:
             await self._send_initial_repaint(session_name, websocket)
+            # The monitor only speaks up when the state *changes*, and it has
+            # already announced the current one to the clients that were here
+            # first. Replay it so this client also knows whether the pane is a
+            # mouse-mode app (wheel scrolling depends on it).
+            if managed.pane_state is not None:
+                # Built outside the try so a bug in here surfaces instead of
+                # being mistaken for a send failure, and so it is evident that
+                # nothing awaits between reading the state and sending it.
+                message = _pane_state_message(managed.pane_state)
+                try:
+                    await websocket.send_json(message)
+                except Exception as e:
+                    logger.warning(f"Failed to replay pane state for {session_name}: {e}")
 
         return managed
 
@@ -206,18 +314,10 @@ class SessionManager:
                 logger.info(f"Closing PTY for session: {session_name}")
 
                 if managed.read_task:
-                    managed.read_task.cancel()
-                    try:
-                        await managed.read_task
-                    except asyncio.CancelledError:
-                        pass
+                    await _cancel_task(managed.read_task, "Read loop", session_name)
 
-                if managed.copy_mode_task:
-                    managed.copy_mode_task.cancel()
-                    try:
-                        await managed.copy_mode_task
-                    except asyncio.CancelledError:
-                        pass
+                if managed.pane_state_task:
+                    await _cancel_task(managed.pane_state_task, "Pane state monitor", session_name)
 
                 managed.pty.close()
                 del self._sessions[session_name]
@@ -384,12 +484,18 @@ class SessionManager:
         except Exception as e:
             logger.error(f"Windows broadcast loop error: {e}")
 
-    async def _poll_copy_mode(self, session_name: str) -> bool | None:
-        """Return True/False for copy-mode active, or None if the probe failed.
+    async def _poll_pane_state(self, session_name: str) -> PaneState | None:
+        """Return the pane's copy-mode + mouse-app state, or None if the probe failed.
 
-        On failure, kill+reap the subprocess so its stdout/stderr pipes are
-        closed; otherwise the 250ms polling loop leaks two fds per failure
-        until EMFILE.
+        The reap runs in a ``finally`` rather than per-exception: any escape
+        route - timeout, cancellation on session teardown, an unenumerated bug,
+        even KeyboardInterrupt - otherwise leaks the child's stdout/stderr pipes,
+        and at one poll per 250ms that reaches EMFILE. It costs nothing on the
+        success path because a completed ``communicate()`` has already reaped.
+
+        Every statement that can raise stays inside the try - notably the decode,
+        whose UnicodeDecodeError is a ValueError, so undecodable output degrades
+        to None instead of escaping.
         """
         proc = None
         try:
@@ -399,45 +505,76 @@ class SessionManager:
                 "-p",
                 "-t",
                 session_name,
-                "#{pane_mode}",
+                _PANE_STATE_FORMAT,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=1.0)
-            return stdout.decode().strip() == "copy-mode"
+            return _parse_pane_state(stdout.decode())
         except (TimeoutError, OSError, ValueError):
-            if proc is not None and proc.returncode is None:
-                try:
-                    proc.kill()
-                except ProcessLookupError:
-                    pass
-                try:
-                    await proc.wait()
-                except Exception:  # noqa: S110 - best-effort reap
-                    pass
             return None
+        finally:
+            await _kill_and_reap(proc)
 
-    async def _copy_mode_monitor(self, session_name: str) -> None:
-        """Poll tmux pane_mode every 250ms and broadcast copy-mode state changes."""
-        last_active = False
+    async def _pane_state_monitor(self, session_name: str) -> None:
+        """Poll tmux pane state every 250ms and broadcast changes.
+
+        ``managed.pane_state`` starts as None so the first successful poll is
+        always sent: a client that connects while a fullscreen mouse-mode app is
+        already running has to learn ``mouse_app`` even though nothing changes
+        after it connects. Later joiners get the same state replayed by
+        register_client, because from here nothing has changed.
+
+        A failed poll (None) is not a state change - it leaves the last known
+        state in place rather than forcing a re-broadcast on every tmux hiccup.
+
+        Unexpected errors are logged and the loop keeps going. Letting one kill
+        the task would stop every future update and, worse, poison teardown:
+        awaiting a failed task re-raises, so unregister_client would skip
+        pty.close() and leave a dead PTY cached under this name.
+        """
+        consecutive_failures = 0
         try:
             while True:
-                await asyncio.sleep(0.25)
+                await asyncio.sleep(_PANE_POLL_INTERVAL)
                 managed = self._sessions.get(session_name)
                 if not managed or not managed.clients:
                     break
-                active = await self._poll_copy_mode(session_name)
-                if active is None or active == last_active:
-                    continue
-                last_active = active
-                message = {"type": "copy_mode", "active": active}
-                for client in list(managed.clients):
-                    try:
-                        await client.send_json(message)
-                    except Exception:  # noqa: S110
-                        pass
+                try:
+                    await self._poll_and_broadcast_pane_state(session_name, managed)
+                except Exception:
+                    # Once per outage, not once per poll. The errors this guard
+                    # exists for are typically deterministic - a parse bug, a
+                    # format variable some tmux build renders differently - so
+                    # they recur every interval, and an unthrottled traceback at
+                    # 4 Hz would bury the journal for the life of the session.
+                    consecutive_failures += 1
+                    if consecutive_failures == 1:
+                        logger.exception(f"Pane state poll failed for {session_name}")
+                else:
+                    if consecutive_failures:
+                        logger.info(
+                            f"Pane state poll recovered for {session_name} after "
+                            f"{consecutive_failures} consecutive failure(s)"
+                        )
+                    consecutive_failures = 0
         except asyncio.CancelledError:
             pass
+
+    async def _poll_and_broadcast_pane_state(
+        self, session_name: str, managed: ManagedSession
+    ) -> None:
+        """Sample the pane once and, if the state changed, tell every client."""
+        state = await self._poll_pane_state(session_name)
+        if state is None or state == managed.pane_state:
+            return
+        managed.pane_state = state
+        message = _pane_state_message(state)
+        for client in list(managed.clients):
+            try:
+                await client.send_json(message)
+            except Exception:  # noqa: S110 - best-effort broadcast
+                pass
 
     async def _notify_session_dead(self, session_name: str) -> None:
         """Send session_dead message to all connected clients."""
@@ -569,10 +706,14 @@ class SessionManager:
             managed = self._sessions.pop(session_name, None)
             if managed is None:
                 return
+            # Cancel without awaiting, unlike unregister_client: this is the
+            # "tmux session already died" path, so a task that errored on the way
+            # down is expected noise rather than something to report. Not
+            # awaiting also means a dead task can't re-raise into this teardown.
             if managed.read_task:
                 managed.read_task.cancel()
-            if managed.copy_mode_task:
-                managed.copy_mode_task.cancel()
+            if managed.pane_state_task:
+                managed.pane_state_task.cancel()
             try:
                 managed.pty.close()
             except Exception as e:

--- a/backend/lumbergh/tests/test_session_manager.py
+++ b/backend/lumbergh/tests/test_session_manager.py
@@ -1,111 +1,226 @@
-"""Tests for SessionManager — specifically the copy-mode poll cleanup.
+"""Tests for SessionManager.
 
-Regression: the 250ms copy-mode polling loop used to swallow subprocess
-failures without killing the child, leaking stdout/stderr pipes until the
-backend hit EMFILE. These tests lock down the kill+reap contract.
+Covers the tmux pane-state probe (parsing, and the kill+reap contract that keeps
+the 250ms poll loop from leaking fds until EMFILE), the monitor that broadcasts
+that state to terminal WebSocket clients, the replay that gives a client joining
+a pooled session the current state, and "latest active device wins" sizing.
 """
 
-from typing import cast
+import asyncio
+import contextlib
+import logging
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
 
-from lumbergh.session_manager import ManagedSession, SessionManager, TerminalClient
+if TYPE_CHECKING:
+    from collections.abc import Sized
+
+from lumbergh.session_manager import (
+    ManagedSession,
+    PaneState,
+    SessionManager,
+    TerminalClient,
+    _parse_pane_state,
+)
 
 
 def _make_proc(stdout: bytes = b"", returncode: int | None = None) -> MagicMock:
-    """Build a mock asyncio subprocess. returncode=None means 'still running'."""
+    """Build a mock asyncio subprocess. returncode=None means 'still running'.
+
+    A completed communicate() sets returncode, like the real thing: production
+    communicate() awaits wait() internally, so it never leaves a reaped-but-
+    unrecorded child. Getting this wrong is what made an unconditional reap look
+    like it would kill on the success path. Tests that patch wait_for to raise
+    never let communicate() finish, so their proc stays "still running" and the
+    kill+reap contract is still exercised.
+    """
     proc = MagicMock()
-    proc.communicate = AsyncMock(return_value=(stdout, b""))
+    proc.returncode = returncode
+
+    async def communicate() -> tuple[bytes, bytes]:
+        proc.returncode = 0
+        return (stdout, b"")
+
+    proc.communicate = AsyncMock(side_effect=communicate)
     proc.wait = AsyncMock(return_value=0)
     proc.kill = MagicMock()
-    proc.returncode = returncode
     return proc
-
-
-async def test_poll_copy_mode_returns_true_when_pane_in_copy_mode(mocker: MockerFixture) -> None:
-    proc = _make_proc(stdout=b"copy-mode\n")
-    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
-
-    result = await SessionManager()._poll_copy_mode("s1")
-
-    assert result is True
-    proc.kill.assert_not_called()
-
-
-async def test_poll_copy_mode_returns_false_for_normal_pane(mocker: MockerFixture) -> None:
-    proc = _make_proc(stdout=b"\n")
-    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
-
-    result = await SessionManager()._poll_copy_mode("s1")
-
-    assert result is False
-    proc.kill.assert_not_called()
 
 
 def _fail_wait_for(exc: BaseException):
     """wait_for side_effect that closes the awaited coroutine before raising,
     so AsyncMock-produced coroutines don't linger as un-awaited warnings."""
 
-    async def _raise(coro, timeout):  # noqa: ARG001 — signature must match asyncio.wait_for
+    async def _raise(coro, timeout):  # noqa: ARG001 - signature must match asyncio.wait_for
         coro.close()
         raise exc
 
     return _raise
 
 
-async def test_poll_copy_mode_reaps_proc_on_timeout(mocker: MockerFixture) -> None:
+def test_parse_pane_state_plain_shell() -> None:
+    assert _parse_pane_state("|000\n") == PaneState(copy_mode=False, mouse_app=False)
+
+
+def test_parse_pane_state_copy_mode() -> None:
+    assert _parse_pane_state("copy-mode|000\n") == PaneState(copy_mode=True, mouse_app=False)
+
+
+def test_parse_pane_state_mouse_app() -> None:
+    """A fullscreen mouse-mode TUI (Claude Code) sets the tmux mouse flags."""
+    assert _parse_pane_state("|111\n") == PaneState(copy_mode=False, mouse_app=True)
+
+
+def test_parse_pane_state_any_single_mouse_flag_counts() -> None:
+    """Only mouse_standard_flag set is still a mouse app."""
+    assert _parse_pane_state("|001\n") == PaneState(copy_mode=False, mouse_app=True)
+
+
+def test_parse_pane_state_fullscreen_without_mouse_is_not_a_mouse_app() -> None:
+    """`less` is on the alternate screen but never asks for the mouse, so tmux
+    still owns the wheel and the client must not take it over."""
+    assert _parse_pane_state("|000\n") == PaneState(copy_mode=False, mouse_app=False)
+
+
+def test_parse_pane_state_tolerates_unknown_format_variable() -> None:
+    """A tmux too old to know these variables yields empty output. Falling back
+    to mouse_app=False keeps the safe native-scroll path."""
+    assert _parse_pane_state("") == PaneState(copy_mode=False, mouse_app=False)
+
+
+async def test_poll_pane_state_reports_copy_mode(mocker: MockerFixture) -> None:
+    proc = _make_proc(stdout=b"copy-mode|000\n")
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+
+    result = await SessionManager()._poll_pane_state("s1")
+
+    assert result == PaneState(copy_mode=True, mouse_app=False)
+    proc.kill.assert_not_called()
+
+
+async def test_poll_pane_state_reports_mouse_app(mocker: MockerFixture) -> None:
+    proc = _make_proc(stdout=b"|111\n")
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+
+    result = await SessionManager()._poll_pane_state("s1")
+
+    assert result == PaneState(copy_mode=False, mouse_app=True)
+    proc.kill.assert_not_called()
+
+
+async def test_poll_pane_state_returns_false_for_normal_pane(mocker: MockerFixture) -> None:
+    proc = _make_proc(stdout=b"|000\n")
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+
+    result = await SessionManager()._poll_pane_state("s1")
+
+    assert result == PaneState(copy_mode=False, mouse_app=False)
+    proc.kill.assert_not_called()
+
+
+async def test_poll_pane_state_returns_none_on_undecodable_output(mocker: MockerFixture) -> None:
+    """Undecodable bytes must degrade to None, the safe native path, rather than
+    escaping. The monitor now logs and continues, so an escape is survivable, but
+    a probe that raises instead of reporting "unknown" would drop a real sample
+    on every hiccup and log noise for a case with a defined answer."""
+    proc = _make_proc(stdout=b"\xff\xfe|000\n")
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+
+    assert await SessionManager()._poll_pane_state("s1") is None
+
+
+async def test_poll_pane_state_reaps_proc_on_timeout(mocker: MockerFixture) -> None:
     """TimeoutError during communicate() must kill and await the proc so pipes close."""
     proc = _make_proc(returncode=None)
     mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
     mocker.patch("asyncio.wait_for", side_effect=_fail_wait_for(TimeoutError()))
 
-    result = await SessionManager()._poll_copy_mode("s1")
+    result = await SessionManager()._poll_pane_state("s1")
 
     assert result is None
     proc.kill.assert_called_once()
-    proc.wait.assert_called_once()
+    proc.wait.assert_awaited_once()
 
 
-async def test_poll_copy_mode_reaps_proc_on_oserror(mocker: MockerFixture) -> None:
+async def test_poll_pane_state_reaps_proc_on_oserror(mocker: MockerFixture) -> None:
     """OSError (e.g. EMFILE) during communicate() must also reap the proc."""
     proc = _make_proc(returncode=None)
     mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
-    mocker.patch(
-        "asyncio.wait_for",
-        side_effect=_fail_wait_for(OSError(24, "Too many open files")),
-    )
+    mocker.patch("asyncio.wait_for", side_effect=_fail_wait_for(OSError("boom")))
 
-    result = await SessionManager()._poll_copy_mode("s1")
+    result = await SessionManager()._poll_pane_state("s1")
 
     assert result is None
     proc.kill.assert_called_once()
-    proc.wait.assert_called_once()
+    proc.wait.assert_awaited_once()
 
 
-async def test_poll_copy_mode_skips_kill_if_proc_already_exited(mocker: MockerFixture) -> None:
-    """If returncode is set, proc has exited — don't try to kill it again."""
+async def test_poll_pane_state_reaps_proc_on_cancellation(mocker: MockerFixture) -> None:
+    """Session teardown cancels the monitor, which can land mid-communicate().
+    The child must still be killed, and the cancellation must propagate."""
+    proc = _make_proc(returncode=None)
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+    mocker.patch("asyncio.wait_for", side_effect=_fail_wait_for(asyncio.CancelledError()))
+
+    with pytest.raises(asyncio.CancelledError):
+        await SessionManager()._poll_pane_state("s1")
+
+    proc.kill.assert_called_once()
+    proc.wait.assert_awaited_once()
+
+
+async def test_poll_pane_state_reaps_proc_on_unexpected_error(mocker: MockerFixture) -> None:
+    """The reap has to cover exceptions nobody enumerated, or the EMFILE
+    pipe-leak class stays open for every failure mode not on the list."""
+    proc = _make_proc(returncode=None)
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+    mocker.patch("asyncio.wait_for", side_effect=_fail_wait_for(IndexError("boom")))
+
+    with pytest.raises(IndexError):
+        await SessionManager()._poll_pane_state("s1")
+
+    proc.kill.assert_called_once()
+    proc.wait.assert_awaited_once()
+
+
+async def test_poll_pane_state_survives_a_kill_that_errors(mocker: MockerFixture) -> None:
+    """The reap runs in a finally, while an exception may already be propagating,
+    so it must not raise: doing so would replace the real error with a confusing
+    one. It must still try to reap after a failed kill."""
+    proc = _make_proc(returncode=None)
+    proc.kill.side_effect = PermissionError("operation not permitted")
+    mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
+    mocker.patch("asyncio.wait_for", side_effect=_fail_wait_for(TimeoutError()))
+
+    assert await SessionManager()._poll_pane_state("s1") is None
+    proc.wait.assert_awaited_once()
+
+
+async def test_poll_pane_state_skips_kill_if_proc_already_exited(mocker: MockerFixture) -> None:
+    """If returncode is set, proc has exited - don't try to kill it again."""
     proc = _make_proc(returncode=0)
     mocker.patch("asyncio.create_subprocess_exec", return_value=proc)
     mocker.patch("asyncio.wait_for", side_effect=_fail_wait_for(TimeoutError()))
 
-    result = await SessionManager()._poll_copy_mode("s1")
+    result = await SessionManager()._poll_pane_state("s1")
 
     assert result is None
     proc.kill.assert_not_called()
 
 
-async def test_poll_copy_mode_returns_none_when_spawn_itself_fails(
+async def test_poll_pane_state_returns_none_when_spawn_itself_fails(
     mocker: MockerFixture,
 ) -> None:
-    """If subprocess spawn raises OSError (EMFILE), there's no proc to reap — just bail."""
+    """If subprocess spawn raises OSError, there's no proc to reap - just bail."""
     mocker.patch(
         "asyncio.create_subprocess_exec",
-        side_effect=OSError(24, "Too many open files"),
+        side_effect=OSError("no tmux"),
     )
 
-    result = await SessionManager()._poll_copy_mode("s1")
+    result = await SessionManager()._poll_pane_state("s1")
 
     assert result is None
 
@@ -201,3 +316,308 @@ async def test_disconnect_lets_remaining_device_reclaim_window() -> None:
 
     assert (managed.pty.cols, managed.pty.rows) == (200, 50)
     assert _last_sync(desktop) == (200, 50)
+
+
+class _RecordingClient:
+    """Minimal stand-in for TerminalClient that records broadcast messages."""
+
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+
+    async def send_json(self, message: dict) -> None:
+        self.messages.append(message)
+
+
+@pytest.fixture
+def _fast_polling(mocker: MockerFixture) -> None:
+    """Shorten the monitor's poll interval so tests don't wait 250ms per tick.
+
+    Still a real asyncio.sleep, just a shorter one - the loop keeps yielding to
+    the event loop, which is exactly what replacing asyncio.sleep with a bare
+    AsyncMock destroys (see _run_monitor_until).
+
+    Must not drop below _run_monitor_until's 10ms check granularity. At 10ms the
+    monitor's period is that sleep *plus* the poll work, so it can never gain a
+    full tick on the checker and the exact-count assertions hold. Going lower
+    lets it overshoot: at 5ms, the exact-list assertion in
+    test_monitor_treats_a_failed_poll_as_no_change fails ~98% of the time.
+    """
+    mocker.patch("lumbergh.session_manager._PANE_POLL_INTERVAL", 0.01)
+
+
+async def _run_monitor_until(
+    mgr: SessionManager, session_name: str, observed: "Sized", count: int, what: str
+) -> None:
+    """Run the monitor until `observed` holds `count` items, then cancel it.
+
+    `observed` is a collection the monitor appends to indirectly - broadcasts
+    recorded by a _RecordingClient, or polls recorded by a stubbed
+    _poll_pane_state. Gating on recorded progress rather than on elapsed wall
+    clock means a starved event loop can only make the test slower, never flaky.
+
+    Deliberately does NOT patch asyncio.sleep. A bare AsyncMock replacement
+    never yields to the event loop, which turns the monitor's poll loop into a
+    tight non-yielding spin and hangs the test. Shortening the interval (see the
+    _fast_polling fixture) keeps the sleep real.
+    """
+    task = asyncio.create_task(mgr._pane_state_monitor(session_name))
+    try:
+        for _ in range(300):  # ~3s ceiling at 10ms granularity
+            if len(observed) >= count:
+                return
+            await asyncio.sleep(0.01)
+        raise AssertionError(f"only got {len(observed)} {what}, wanted {count}")
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+def _seed_session(mgr: SessionManager, name: str, client: _RecordingClient) -> ManagedSession:
+    managed = ManagedSession(pty=_fake_pty())
+    managed.clients.add(client)
+    mgr._sessions[name] = managed
+    return managed
+
+
+@pytest.mark.usefixtures("_fast_polling")
+async def test_monitor_broadcasts_first_poll_even_when_state_never_changes(
+    mocker: MockerFixture,
+) -> None:
+    """A client connecting while Claude Code is already running must still learn
+    mouse_app=True - otherwise the wheel stays on the native path forever."""
+    mgr = SessionManager()
+    client = _RecordingClient()
+    _seed_session(mgr, "s1", client)
+    mocker.patch.object(
+        mgr, "_poll_pane_state", return_value=PaneState(copy_mode=False, mouse_app=True)
+    )
+
+    await _run_monitor_until(mgr, "s1", client.messages, 1, "messages")
+
+    assert client.messages[0] == {"type": "copy_mode", "active": False, "mouse_app": True}
+
+
+@pytest.mark.usefixtures("_fast_polling")
+async def test_monitor_broadcasts_when_only_mouse_app_changes(mocker: MockerFixture) -> None:
+    mgr = SessionManager()
+    client = _RecordingClient()
+    _seed_session(mgr, "s1", client)
+    # A finite side_effect list would raise StopIteration once the poll loop
+    # outruns it. Clamp to the final state instead.
+    pending = iter(
+        [
+            PaneState(copy_mode=False, mouse_app=False),
+            PaneState(copy_mode=False, mouse_app=True),
+        ]
+    )
+    final = PaneState(copy_mode=False, mouse_app=True)
+
+    async def poll(_session_name: str) -> PaneState:
+        return next(pending, final)
+
+    mocker.patch.object(mgr, "_poll_pane_state", side_effect=poll)
+
+    await _run_monitor_until(mgr, "s1", client.messages, 2, "messages")
+
+    assert client.messages[0]["mouse_app"] is False
+    assert client.messages[1]["mouse_app"] is True
+
+
+@pytest.mark.usefixtures("_fast_polling")
+async def test_monitor_does_not_rebroadcast_unchanged_state(mocker: MockerFixture) -> None:
+    mgr = SessionManager()
+    client = _RecordingClient()
+    _seed_session(mgr, "s1", client)
+    state = PaneState(copy_mode=True, mouse_app=False)
+    polls: list[PaneState | None] = []
+
+    async def poll(_session_name: str) -> PaneState:
+        polls.append(state)
+        return state
+
+    mocker.patch.object(mgr, "_poll_pane_state", side_effect=poll)
+
+    # Wait for four identical polls: the first broadcasts, the rest must stay
+    # silent. Gated on polls (not elapsed time) so the assertion means "four
+    # polls happened and one message was sent".
+    await _run_monitor_until(mgr, "s1", polls, 4, "polls")
+
+    assert len(client.messages) == 1
+
+
+@pytest.mark.usefixtures("_fast_polling")
+async def test_monitor_treats_a_failed_poll_as_no_change(mocker: MockerFixture) -> None:
+    """tmux display-message can time out on a loaded box. That is not a state
+    change - resetting the remembered state on failure would re-broadcast
+    identical state on every hiccup and churn the frontend."""
+    mgr = SessionManager()
+    client = _RecordingClient()
+    _seed_session(mgr, "s1", client)
+    state = PaneState(copy_mode=True, mouse_app=False)
+    polls: list[PaneState | None] = []
+
+    async def poll(_session_name: str) -> PaneState | None:
+        # S, S, None, S - the failed probe sits between identical states.
+        result = None if len(polls) == 2 else state
+        polls.append(result)
+        return result
+
+    mocker.patch.object(mgr, "_poll_pane_state", side_effect=poll)
+
+    await _run_monitor_until(mgr, "s1", polls, 4, "polls")
+
+    assert polls == [state, state, None, state]
+    assert len(client.messages) == 1
+
+
+@pytest.mark.usefixtures("_fast_polling")
+async def test_monitor_survives_an_unexpected_poll_error(mocker: MockerFixture) -> None:
+    """An unexpected exception must not kill the monitor task. _parse_pane_state
+    is total today, but the next format variable parsed with split()[2] raises
+    IndexError, which is not a ValueError. A dead monitor stops every future
+    update AND poisons unregister_client's teardown."""
+    mgr = SessionManager()
+    client = _RecordingClient()
+    _seed_session(mgr, "s1", client)
+    state = PaneState(copy_mode=False, mouse_app=True)
+    polls: list[str] = []
+
+    async def poll(_session_name: str) -> PaneState:
+        polls.append("called")
+        if len(polls) == 1:
+            raise IndexError("a future format-variable parse bug")
+        return state
+
+    mocker.patch.object(mgr, "_poll_pane_state", side_effect=poll)
+
+    await _run_monitor_until(mgr, "s1", client.messages, 1, "messages")
+
+    # Recovered on the poll after the exception rather than dying on it.
+    assert client.messages == [{"type": "copy_mode", "active": False, "mouse_app": True}]
+
+
+@pytest.mark.usefixtures("_fast_polling")
+async def test_monitor_logs_a_persistent_poll_failure_only_once(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The guard exists to survive unenumerated bugs, and those are usually
+    deterministic - so they fail on every poll. At 4 Hz, logging each one buries
+    the journal in identical tracebacks for as long as the session lives. One
+    record per outage, with the traceback intact."""
+    mgr = SessionManager()
+    client = _RecordingClient()
+    _seed_session(mgr, "s1", client)
+    polls: list[str] = []
+
+    async def poll(_session_name: str) -> PaneState:
+        polls.append("called")
+        raise IndexError("deterministic parse bug")
+
+    mocker.patch.object(mgr, "_poll_pane_state", side_effect=poll)
+
+    with caplog.at_level(logging.INFO, logger="lumbergh.session_manager"):
+        await _run_monitor_until(mgr, "s1", polls, 5, "polls")
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert len(errors) == 1, f"{len(polls)} failing polls produced {len(errors)} records"
+    assert errors[0].exc_info is not None, "the one record we keep must carry the traceback"
+
+
+@pytest.mark.usefixtures("_fast_polling")
+async def test_monitor_logs_again_after_a_recovery(
+    mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Throttling is per outage, not for the life of the monitor: a fresh failure
+    after a good poll is news again, and the recovery itself is logged so an
+    operator can see how long the window was."""
+    mgr = SessionManager()
+    client = _RecordingClient()
+    _seed_session(mgr, "s1", client)
+    polls: list[str] = []
+
+    async def poll(_session_name: str) -> PaneState:
+        # fail, fail, succeed, fail, fail
+        polls.append("called")
+        if len(polls) == 3:
+            return PaneState(copy_mode=False, mouse_app=True)
+        raise IndexError("flapping")
+
+    mocker.patch.object(mgr, "_poll_pane_state", side_effect=poll)
+
+    with caplog.at_level(logging.INFO, logger="lumbergh.session_manager"):
+        await _run_monitor_until(mgr, "s1", polls, 5, "polls")
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert len(errors) == 2
+    assert any("recovered" in r.message for r in caplog.records if r.levelno == logging.INFO)
+
+
+async def test_unregister_closes_pty_even_if_the_monitor_died(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Awaiting a task that failed re-raises its exception. If teardown doesn't
+    absorb that, pty.close() and the _sessions removal are skipped - leaking the
+    PTY and leaving an entry that hands out a dead PTY forever."""
+    mgr = SessionManager()
+    client = AsyncMock()
+    managed = _register(mgr, "s", client)
+
+    async def boom() -> None:
+        raise NotImplementedError("boom")
+
+    managed.pane_state_task = asyncio.create_task(boom())
+    # Await it here so the failure is deterministic, not timing-dependent. A Task
+    # re-raises its stored exception on every await, so teardown still hits it.
+    with contextlib.suppress(NotImplementedError):
+        await managed.pane_state_task
+
+    with caplog.at_level(logging.ERROR, logger="lumbergh.session_manager"):
+        await mgr.unregister_client("s", client)
+
+    cast("MagicMock", managed.pty).close.assert_called_once()
+    assert "s" not in mgr._sessions
+    # Absorbing the error must not mean hiding it. This fires at most once per
+    # teardown, so it is the one place the traceback is both free and essential.
+    assert [r for r in caplog.records if r.exc_info], "dead task logged with no traceback"
+
+
+@pytest.mark.usefixtures("_fast_polling")
+async def test_client_joining_pooled_session_gets_current_pane_state(
+    mocker: MockerFixture,
+) -> None:
+    """The monitor is created once per PTY and only speaks on change, so a second
+    client on a pooled session (pop-out window, second device, cloud tunnel)
+    would otherwise never learn mouse_app and would lose its wheel scrolling."""
+    mgr = SessionManager()
+    first = _RecordingClient()
+    _seed_session(mgr, "s1", first)
+    mocker.patch.object(
+        mgr, "_poll_pane_state", return_value=PaneState(copy_mode=False, mouse_app=True)
+    )
+    # Joining an existing PTY asks tmux for a native redraw; pretend it worked so
+    # register_client doesn't fall back to a capture-pane snapshot.
+    mocker.patch("lumbergh.session_manager.refresh_client", return_value=True)
+
+    await _run_monitor_until(mgr, "s1", first.messages, 1, "messages")
+
+    second = _RecordingClient()
+    await mgr.register_client("s1", second)
+
+    assert second.messages == [{"type": "copy_mode", "active": False, "mouse_app": True}]
+
+
+async def test_client_joining_before_any_poll_is_not_replayed_anything(
+    mocker: MockerFixture,
+) -> None:
+    """Before the monitor's first poll there is nothing to replay - the client
+    learns the state from that first broadcast instead."""
+    mgr = SessionManager()
+    client = _RecordingClient()
+    managed = _seed_session(mgr, "s1", client)
+    mocker.patch("lumbergh.session_manager.refresh_client", return_value=True)
+
+    assert managed.pane_state is None
+    await mgr.register_client("s1", client)
+
+    assert client.messages == []

--- a/backend/lumbergh/tunnel.py
+++ b/backend/lumbergh/tunnel.py
@@ -44,7 +44,10 @@ class CloudClient:
         elif msg_type == "session_dead":
             await self._tunnel.send({"type": "session_dead", "session": self._session_name})
         elif msg_type == "copy_mode":
-            # Skip copy_mode for remote clients - not useful on mobile
+            # Carries copy-mode + mouse_app pane state. Forwarding it would need
+            # a matching change in the cloud server/frontend, which lives in a
+            # separate repo; dropping it leaves remote clients on the native
+            # wheel-scroll path, which is the safe default.
             pass
         elif msg_type == "resize_sync":
             # Skip resize_sync for cloud clients

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -43,7 +43,8 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
-        "vite-plugin-pwa": "^1.2.0"
+        "vite-plugin-pwa": "^1.2.0",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -93,6 +94,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2892,6 +2894,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
@@ -3259,6 +3268,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -3521,6 +3541,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3602,6 +3629,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3681,6 +3709,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -3969,6 +3998,129 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.28",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.28.tgz",
@@ -4016,6 +4168,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4110,6 +4263,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -4271,6 +4434,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4381,6 +4545,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4629,6 +4803,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -5029,6 +5204,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -5482,6 +5658,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5600,6 +5783,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5809,6 +5993,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -8940,6 +9134,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -9309,6 +9517,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9318,6 +9527,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9824,6 +10034,7 @@
       "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10143,6 +10354,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10228,6 +10446,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -10508,6 +10740,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -10532,6 +10771,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tr46": {
@@ -10696,6 +10945,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11046,6 +11296,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11143,6 +11394,96 @@
       "peerDependenciesMeta": {
         "@vite-pwa/assets-generator": {
           "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -11329,6 +11670,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -11496,6 +11854,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11563,6 +11922,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -11736,6 +12096,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
     "preview": "vite preview"
@@ -50,6 +52,7 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",
-    "vite-plugin-pwa": "^1.2.0"
+    "vite-plugin-pwa": "^1.2.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -5,6 +5,8 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import { Unicode11Addon } from '@xterm/addon-unicode11'
 import '@xterm/xterm/css/xterm.css'
 import { useTerminalSocket } from '../hooks/useTerminalSocket'
+import type { PaneState } from '../hooks/useTerminalSocket'
+import { createWheelPager } from '../utils/wheelScroll'
 import { getApiBase } from '../config'
 import { useTheme } from '../hooks/useTheme'
 import TerminalHeader from './TerminalHeader'
@@ -138,6 +140,11 @@ export default memo(function Terminal({
   const [scrollMode, setScrollMode] = useState(false)
   const scrollModeRef = useRef(false)
 
+  // Whether the pane's foreground app asked tmux for mouse reporting. Defaults
+  // to false so the wheel keeps the safe native path until the backend's first
+  // pane-state broadcast lands (within 250ms of connecting).
+  const mouseAppRef = useRef(false)
+
   // Track terminal focus (for focus-border styling on desktop)
   const [hasFocus, setHasFocus] = useState(false)
 
@@ -247,8 +254,9 @@ export default memo(function Terminal({
     [sessionName]
   )
 
-  const handleCopyMode = useCallback((active: boolean) => {
-    setScrollMode(active)
+  const handlePaneState = useCallback((state: PaneState) => {
+    setScrollMode(state.copyMode)
+    mouseAppRef.current = state.mouseApp
   }, [])
 
   const logFit = useCallback(
@@ -361,7 +369,7 @@ export default memo(function Terminal({
     sessionName,
     onData: handleData,
     onResizeSync: handleResizeSync,
-    onCopyMode: handleCopyMode,
+    onPaneState: handlePaneState,
     onConnect: handleConnect,
     getInitialSize,
   })
@@ -419,6 +427,13 @@ export default memo(function Terminal({
     if (!containerRef.current) return
 
     containerRef.current.innerHTML = ''
+
+    // This component is not keyed on sessionName, so the instance (and its
+    // refs) survives a session switch even though this effect re-runs. Clear
+    // the mouse-app flag so the new pane starts on the safe native path instead
+    // of inheriting the old pane's takeover until the first pane-state
+    // broadcast lands.
+    mouseAppRef.current = false
 
     const style = getComputedStyle(document.documentElement)
     const termBg = style.getPropertyValue('--terminal-bg').trim()
@@ -731,28 +746,47 @@ export default memo(function Terminal({
     // sequences through the same WebSocket path as real keystrokes.
     const PAGE_UP = '\x1b[5~'
     const PAGE_DOWN = '\x1b[6~'
-    // Pixels of wheel/drag travel per PageUp/PageDown emitted. Raise if it
-    // scrolls too fast, lower if too slow — these are the knobs to tune feel.
-    const WHEEL_PAGE_PX = 160
+    // Pixels of touch-drag travel per PageUp/PageDown emitted.
     const TOUCH_PAGE_PX = 45
     const scrollByKeys = (up: boolean, count: number) => {
       if (count <= 0) return
       sendRef.current((up ? PAGE_UP : PAGE_DOWN).repeat(count))
     }
 
-    // Desktop wheel → PageUp/PageDown. preventDefault/stopPropagation so xterm
-    // doesn't ALSO handle the wheel (double-scroll / its own dodgy reports).
-    let wheelAccum = 0
+    // Desktop wheel. The pager decides whether this pane is ours to drive; see
+    // utils/wheelScroll.ts. Panes that are not fullscreen mouse-mode apps get
+    // 'native' and the event is left alone so xterm's mouse report reaches tmux,
+    // which scrolls its own history.
+    const wheelPager = createWheelPager()
     const onWheel = (e: WheelEvent) => {
-      e.preventDefault()
-      e.stopPropagation()
-      // Normalize line-mode deltas (some mice report deltaMode 1) to pixels.
-      wheelAccum += e.deltaMode === 1 ? e.deltaY * 16 : e.deltaY
-      const steps = Math.trunc(wheelAccum / WHEEL_PAGE_PX)
-      if (steps !== 0) {
-        // deltaY < 0 = scroll up = PageUp; > 0 = down = PageDown.
-        scrollByKeys(steps < 0, Math.abs(steps))
-        wheelAccum -= steps * WHEEL_PAGE_PX
+      const action = wheelPager.feed({
+        deltaY: e.deltaY,
+        deltaX: e.deltaX,
+        deltaMode: e.deltaMode,
+        timeStamp: e.timeStamp,
+        ctrlKey: e.ctrlKey,
+        mouseApp: mouseAppRef.current,
+      })
+      switch (action.type) {
+        case 'native':
+          return
+        case 'page':
+          e.preventDefault()
+          e.stopPropagation()
+          scrollByKeys(action.direction === 'up', 1)
+          return
+        case 'swallow':
+          // Travel banked but still short of a page: consume it so xterm does
+          // not also act on the same wheel event.
+          e.preventDefault()
+          e.stopPropagation()
+          return
+        default: {
+          // Exhaustiveness: a new WheelAction variant becomes a type error here
+          // rather than being silently treated as 'swallow'.
+          const unhandled: never = action
+          void unhandled
+        }
       }
     }
 

--- a/frontend/src/hooks/useTerminalSocket.ts
+++ b/frontend/src/hooks/useTerminalSocket.ts
@@ -1,11 +1,19 @@
 import { useRef, useCallback, useEffect, useState } from 'react'
 import { getWsBase } from '../config'
 
+/** Pane state broadcast by the backend's 250ms tmux poll. */
+export interface PaneState {
+  /** tmux is in copy-mode. */
+  copyMode: boolean
+  /** The pane's foreground app asked tmux for mouse reporting. */
+  mouseApp: boolean
+}
+
 interface UseTerminalSocketOptions {
   sessionName: string
   onData: (data: string) => void
   onResizeSync?: (cols: number, rows: number) => void
-  onCopyMode?: (active: boolean) => void
+  onPaneState?: (state: PaneState) => void
   onConnect?: () => void
   onDisconnect?: () => void
   // Hint for the backend so the new PTY spawns at the right size and tmux
@@ -28,7 +36,7 @@ export function useTerminalSocket({
   sessionName,
   onData,
   onResizeSync,
-  onCopyMode,
+  onPaneState,
   onConnect,
   onDisconnect,
   getInitialSize,
@@ -48,17 +56,17 @@ export function useTerminalSocket({
   // Store callbacks in refs to avoid recreating connect() on every render
   const onDataRef = useRef(onData)
   const onResizeSyncRef = useRef(onResizeSync)
-  const onCopyModeRef = useRef(onCopyMode)
+  const onPaneStateRef = useRef(onPaneState)
   const onConnectRef = useRef(onConnect)
   const onDisconnectRef = useRef(onDisconnect)
 
   useEffect(() => {
     onDataRef.current = onData
     onResizeSyncRef.current = onResizeSync
-    onCopyModeRef.current = onCopyMode
+    onPaneStateRef.current = onPaneState
     onConnectRef.current = onConnect
     onDisconnectRef.current = onDisconnect
-  }, [onData, onResizeSync, onCopyMode, onConnect, onDisconnect])
+  }, [onData, onResizeSync, onPaneState, onConnect, onDisconnect])
 
   const connect = useCallback(() => {
     // Guard against StrictMode/double-effect creating a second WebSocket while
@@ -99,7 +107,12 @@ export function useTerminalSocket({
         } else if (message.type === 'resize_sync') {
           onResizeSyncRef.current?.(message.cols, message.rows)
         } else if (message.type === 'copy_mode') {
-          onCopyModeRef.current?.(message.active)
+          // Wire type is still `copy_mode` for backwards compatibility with a
+          // PWA-cached frontend; it now also carries mouse_app.
+          onPaneStateRef.current?.({
+            copyMode: Boolean(message.active),
+            mouseApp: Boolean(message.mouse_app),
+          })
         } else if (message.type === 'error') {
           setError(message.message)
         } else if (message.type === 'session_dead' || message.type === 'session_not_found') {

--- a/frontend/src/utils/wheelScroll.test.ts
+++ b/frontend/src/utils/wheelScroll.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it } from 'vitest'
+import { createWheelPager } from './wheelScroll'
+import type { WheelAction, WheelPager, WheelSample } from './wheelScroll'
+
+/** The module default, restated so the tests pin the tuning, not just the plumbing. */
+const MIN_INTERVAL_MS = 60
+
+/** A wheel sample with the fields a given test doesn't care about defaulted. */
+function sample(
+  over: Partial<WheelSample> & Pick<WheelSample, 'deltaY' | 'mouseApp'>
+): WheelSample {
+  return { deltaX: 0, deltaMode: 0, timeStamp: 0, ctrlKey: false, ...over }
+}
+
+/** An action tagged with the timestamp of the sample that produced it. */
+interface FedAction {
+  timeStamp: number
+  action: WheelAction
+}
+
+/** Feed a burst of identical deltas, collecting every action returned. */
+function feedBurst(
+  pager: WheelPager,
+  {
+    deltaY,
+    count,
+    mouseApp,
+    deltaX = 0,
+    deltaMode = 0,
+    ctrlKey = false,
+    startMs = 0,
+    stepMs = 5,
+  }: {
+    deltaY: number
+    count: number
+    mouseApp: boolean
+    deltaX?: number
+    deltaMode?: number
+    ctrlKey?: boolean
+    startMs?: number
+    stepMs?: number
+  }
+): FedAction[] {
+  const fed: FedAction[] = []
+  for (let i = 0; i < count; i++) {
+    const timeStamp = startMs + i * stepMs
+    fed.push({
+      timeStamp,
+      action: pager.feed({ deltaY, deltaX, deltaMode, timeStamp, ctrlKey, mouseApp }),
+    })
+  }
+  return fed
+}
+
+const actionsOf = (fed: FedAction[]): WheelAction[] => fed.map((f) => f.action)
+const pagesOf = (fed: FedAction[]): WheelAction[] => actionsOf(fed).filter((a) => a.type === 'page')
+
+const pageUp: WheelAction = { type: 'page', direction: 'up' }
+
+describe('createWheelPager', () => {
+  describe('panes whose app has not asked tmux for mouse reporting', () => {
+    it('always yields "native" so xterm and tmux keep their own scrolling', () => {
+      // This is issue #24: a plain shell must never have its wheel hijacked.
+      const pager = createWheelPager()
+      const fed = feedBurst(pager, { deltaY: -3, count: 100, mouseApp: false })
+      expect(actionsOf(fed).every((a) => a.type === 'native')).toBe(true)
+    })
+
+    it('yields "native" even for a single large wheel notch', () => {
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: -120, mouseApp: false }))).toEqual({ type: 'native' })
+    })
+
+    it('starts from zero when a takeover begins', () => {
+      // Deliberately cannot fail as written: a non-mouse-app event returns
+      // before the accumulator, so there is never anything to carry. It is a
+      // guard against the native path being changed to bank travel. The test
+      // below is the one that catches a real leak.
+      const pager = createWheelPager()
+      feedBurst(pager, { deltaY: -40, count: 5, mouseApp: false })
+      const action = pager.feed(sample({ deltaY: -1, timeStamp: 100, mouseApp: true }))
+      expect(action).toEqual({ type: 'swallow' })
+    })
+
+    it('discards travel buffered by a takeover that ends mid-gesture', () => {
+      // Claude Code exiting while a swipe is in flight. The test above cannot
+      // catch a leak: it starts from mouseApp: false, and a non-mouse-app event
+      // never accumulates anything, so there is nothing there to carry over.
+      // Only this ordering puts real travel in the buffer before the pane goes
+      // native.
+      const pager = createWheelPager()
+      feedBurst(pager, { deltaY: -10, count: 4, mouseApp: true, stepMs: 1 })
+      expect(pager.feed(sample({ deltaY: -10, timeStamp: 10, mouseApp: false }))).toEqual({
+        type: 'native',
+      })
+      // Back under a mouse app 5ms later - far too soon for the idle-gap reset
+      // to help, so a page here would prove the stale 40px survived.
+      const fed = feedBurst(pager, {
+        deltaY: -10,
+        count: 4,
+        mouseApp: true,
+        startMs: 15,
+        stepMs: 1,
+      })
+      expect(pagesOf(fed)).toEqual([])
+    })
+  })
+
+  describe('gestures that are never a transcript scroll', () => {
+    it('leaves a pinch-zoom to the browser', () => {
+      // macOS delivers a trackpad pinch as a wheel event with ctrlKey set.
+      // Cancelling it would page the transcript and block the zoom.
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: -120, ctrlKey: true, mouseApp: true }))).toEqual({
+        type: 'native',
+      })
+    })
+
+    it('does not bank pinch travel toward a page', () => {
+      const pager = createWheelPager()
+      feedBurst(pager, { deltaY: -20, count: 5, mouseApp: true, ctrlKey: true, stepMs: 1 })
+      // 100px of pinch just went by. A real 40px scroll must still be short of
+      // a page. The gap clears the rate-limit floor, so a page here could only
+      // come from the pinch travel having been banked.
+      const action = pager.feed(sample({ deltaY: -40, timeStamp: 200, mouseApp: true }))
+      expect(action).toEqual({ type: 'swallow' })
+    })
+
+    it('leaves a horizontal-dominant swipe to the browser', () => {
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: -3, deltaX: -40, mouseApp: true }))).toEqual({
+        type: 'native',
+      })
+    })
+
+    it('leaves a purely horizontal swipe alone rather than swallowing it', () => {
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: 0, deltaX: 40, mouseApp: true }))).toEqual({
+        type: 'native',
+      })
+    })
+
+    it('does not bank the incidental vertical travel of a sideways swipe', () => {
+      // 30 events of 3px vertical drift is 90px - nearly two pages if counted.
+      const pager = createWheelPager()
+      const fed = feedBurst(pager, {
+        deltaY: -3,
+        deltaX: -40,
+        count: 30,
+        mouseApp: true,
+        stepMs: 1,
+      })
+      expect(actionsOf(fed).every((a) => a.type === 'native')).toBe(true)
+    })
+
+    it('does not let a sideways frame wipe banked vertical travel', () => {
+      const pager = createWheelPager()
+      feedBurst(pager, { deltaY: -10, count: 4, mouseApp: true, stepMs: 1 })
+      // One sideways-dominant frame passes straight through...
+      expect(
+        pager.feed(sample({ deltaY: -1, deltaX: -40, timeStamp: 10, mouseApp: true }))
+      ).toEqual({ type: 'native' })
+      // ...and the 40px it never contributed to is still banked.
+      expect(pager.feed(sample({ deltaY: -20, timeStamp: 20, mouseApp: true }))).toEqual(pageUp)
+    })
+
+    it('still pages a gentle swipe whose frames keep drifting sideways', () => {
+      // 3px of vertical travel per frame with 4px of lateral noise on half the
+      // frames. The noise "dominates" on those frames, and if they cleared the
+      // bank this device would never scroll at all.
+      const pager = createWheelPager()
+      let pages = 0
+      for (let i = 0; i < 60; i++) {
+        const action = pager.feed({
+          deltaY: -3,
+          deltaX: i % 2 === 0 ? -4 : 0,
+          deltaMode: 0,
+          timeStamp: i * 5,
+          ctrlKey: false,
+          mouseApp: true,
+        })
+        if (action.type === 'page') pages++
+      }
+      expect(pages).toBeGreaterThan(0)
+    })
+
+    it('still pages a vertical swipe that drifts slightly sideways', () => {
+      const pager = createWheelPager()
+      const fed = feedBurst(pager, { deltaY: -10, deltaX: -2, count: 5, mouseApp: true, stepMs: 1 })
+      expect(pagesOf(fed)).toEqual([pageUp])
+    })
+  })
+
+  describe('panes whose app owns the mouse (Claude Code)', () => {
+    it('emits a page once a gentle trackpad swipe crosses the threshold', () => {
+      // 20 events x 3px = 60px > the 50px default threshold.
+      const pager = createWheelPager()
+      const fed = feedBurst(pager, { deltaY: -3, count: 20, mouseApp: true })
+      expect(pagesOf(fed)).toEqual([pageUp])
+    })
+
+    it('never lets a wheel event reach xterm', () => {
+      const pager = createWheelPager()
+      const fed = feedBurst(pager, { deltaY: -3, count: 20, mouseApp: true })
+      expect(actionsOf(fed).some((a) => a.type === 'native')).toBe(false)
+    })
+
+    it('maps positive deltaY to a down page', () => {
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: 60, mouseApp: true }))).toEqual({
+        type: 'page',
+        direction: 'down',
+      })
+    })
+
+    it('swallows travel below the threshold', () => {
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: -10, mouseApp: true }))).toEqual({ type: 'swallow' })
+    })
+
+    it('pages at exactly the threshold but not just below it', () => {
+      expect(createWheelPager().feed(sample({ deltaY: -50, mouseApp: true }))).toEqual(pageUp)
+      expect(createWheelPager().feed(sample({ deltaY: -49.9, mouseApp: true }))).toEqual({
+        type: 'swallow',
+      })
+    })
+
+    it('scales deltaMode=1 (line) deltas into pixels', () => {
+      // One real Firefox notch: 3 lines x 40px = 120px.
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: -3, deltaMode: 1, mouseApp: true }))).toEqual(pageUp)
+    })
+
+    it('scales deltaMode=2 (page) deltas into pixels', () => {
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: -1, deltaMode: 2, mouseApp: true }))).toEqual(pageUp)
+    })
+
+    it('treats an unrecognized deltaMode as pixels', () => {
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: -60, deltaMode: 99, mouseApp: true }))).toEqual(pageUp)
+    })
+
+    it('pages a line-mode wheel whose notch is below the threshold, at any cadence', () => {
+      // 1 line = 40px, under the 50px threshold, so this device scrolls only if
+      // banked travel survives between notches. An idle timeout is exactly what
+      // used to starve it, so this sweeps cadences up to 30s: the pager must be
+      // entirely time-independent, not merely tuned to a generous timeout.
+      for (const stepMs of [300, 3000, 30_000]) {
+        const pager = createWheelPager()
+        const fed = feedBurst(pager, {
+          deltaY: -1,
+          deltaMode: 1,
+          count: 10,
+          mouseApp: true,
+          stepMs,
+        })
+        expect(pagesOf(fed).length).toBeGreaterThan(0)
+      }
+    })
+
+    it('pages a sub-threshold pixel-mode wheel at any cadence', () => {
+      // Chrome and Edge on Windows set to "one line at a time" report deltaMode
+      // 0 with roughly 33px per notch, so deltaMode cannot be used to recognize
+      // a discrete wheel and exempt it from the accumulator.
+      for (const stepMs of [300, 3000, 30_000]) {
+        const pager = createWheelPager()
+        const fed = feedBurst(pager, { deltaY: -33, count: 10, mouseApp: true, stepMs })
+        expect(pagesOf(fed).length).toBeGreaterThan(0)
+      }
+    })
+
+    it('pages on every notch of a discrete wheel, however slow the cadence', () => {
+      // Firefox on Windows and Linux: deltaMode 1, 3 lines per notch, ~300ms
+      // of deliberate pause between notches. This is the starvation case - at
+      // 16px per line a notch came to 48px, just under the threshold, and the
+      // gesture reset then dropped it before the next notch landed, so the
+      // pane never scrolled at all.
+      const pager = createWheelPager()
+      const fed = feedBurst(pager, {
+        deltaY: -3,
+        deltaMode: 1,
+        count: 10,
+        mouseApp: true,
+        stepMs: 300,
+      })
+      expect(pagesOf(fed)).toEqual(Array<WheelAction>(10).fill(pageUp))
+    })
+
+    it('pages on every notch of a page-mode wheel at the same cadence', () => {
+      const pager = createWheelPager()
+      const fed = feedBurst(pager, {
+        deltaY: -1,
+        deltaMode: 2,
+        count: 10,
+        mouseApp: true,
+        stepMs: 300,
+      })
+      expect(pagesOf(fed)).toEqual(Array<WheelAction>(10).fill(pageUp))
+    })
+
+    it('ignores a zero delta without disturbing the bank', () => {
+      // The guard has to run before the sign check: Math.sign(0) differs from
+      // the sign of a pending bank, so a zero delta would read as a reversal
+      // and wipe it.
+      const pager = createWheelPager()
+      feedBurst(pager, { deltaY: -10, count: 4, mouseApp: true, stepMs: 1 })
+      expect(pager.feed(sample({ deltaY: 0, timeStamp: 10, mouseApp: true }))).toEqual({
+        type: 'swallow',
+      })
+      // The 40px is still banked, so 20px more crosses the threshold.
+      expect(pager.feed(sample({ deltaY: -20, timeStamp: 20, mouseApp: true }))).toEqual(pageUp)
+    })
+
+    it('ignores non-finite deltas', () => {
+      // Browsers never send these, but the contract is a plain object, so it is
+      // wider than the DOM's. NaN fails every `<`, so an unguarded NaN would
+      // fall through the threshold check and emit a spurious page.
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: Number.NaN, mouseApp: true }))).toEqual({
+        type: 'swallow',
+      })
+      expect(pager.feed(sample({ deltaY: Number.POSITIVE_INFINITY, mouseApp: true }))).toEqual({
+        type: 'swallow',
+      })
+    })
+
+    it('never emits two pages closer together than minIntervalMs', () => {
+      // 400 events x 5px = 2000px of travel inside 400ms: a hard flick plus its
+      // inertia. Spacing is the guarantee the limiter actually makes; a page
+      // count would couple the test to three constants at once.
+      const pager = createWheelPager()
+      const fed = feedBurst(pager, { deltaY: -5, count: 400, mouseApp: true, stepMs: 1 })
+      const pages = fed.filter((f) => f.action.type === 'page')
+      const gaps = pages.slice(1).map((p, i) => p.timeStamp - pages[i].timeStamp)
+      expect(gaps.filter((gap) => gap < MIN_INTERVAL_MS)).toEqual([])
+      // Sanity: it must still scroll, and nowhere near the 40 pages that 2000px
+      // of unmetered travel would have bought.
+      expect(pages.length).toBeGreaterThan(1)
+      expect(pages.length).toBeLessThan(15)
+    })
+
+    it('discards rate-limited travel instead of queueing it', () => {
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: 60, mouseApp: true }))).toEqual({
+        type: 'page',
+        direction: 'down',
+      })
+      // 200px arrives while the floor is down, so it is dropped, not banked.
+      expect(pager.feed(sample({ deltaY: 200, timeStamp: 10, mouseApp: true }))).toEqual({
+        type: 'swallow',
+      })
+      // Once the floor lifts, 1px must not cash in the discarded 200px.
+      expect(pager.feed(sample({ deltaY: 1, timeStamp: 61, mouseApp: true }))).toEqual({
+        type: 'swallow',
+      })
+    })
+
+    it('responds immediately when the gesture reverses direction', () => {
+      const pager = createWheelPager()
+      // Build up 40px of downward travel - not enough to emit a page.
+      feedBurst(pager, { deltaY: 10, count: 4, mouseApp: true, stepMs: 1 })
+      // Reverse after a 197ms pause. Nothing clears the bank on a timer, so
+      // the sign check is the only thing that can drop the residue. It must
+      // take a fresh 50px, and the page must be 'up' rather than being
+      // cancelled out by the old downward residue.
+      const fed = feedBurst(pager, {
+        deltaY: -10,
+        count: 6,
+        mouseApp: true,
+        startMs: 200,
+        stepMs: 1,
+      })
+      expect(pagesOf(fed)).toEqual([pageUp])
+    })
+
+    it('treats a backwards clock as a gesture boundary, not as "too soon"', () => {
+      // Unreachable with WheelEvent.timeStamp in one document, but the contract
+      // takes a plain number. A negative gap used to read as "too soon since
+      // the last page" forever, suppressing every page from then on.
+      const pager = createWheelPager()
+      expect(pager.feed(sample({ deltaY: -60, timeStamp: 10_000, mouseApp: true }))).toEqual(pageUp)
+      const fed = feedBurst(pager, {
+        deltaY: -60,
+        count: 10,
+        mouseApp: true,
+        startMs: 0,
+        stepMs: MIN_INTERVAL_MS,
+      })
+      expect(pagesOf(fed)).toEqual(Array<WheelAction>(10).fill(pageUp))
+    })
+
+    it('honours explicit option overrides', () => {
+      const pager = createWheelPager({ pageThresholdPx: 10, minIntervalMs: 0 })
+      expect(pager.feed(sample({ deltaY: -10, mouseApp: true }))).toEqual(pageUp)
+    })
+  })
+})

--- a/frontend/src/utils/wheelScroll.ts
+++ b/frontend/src/utils/wheelScroll.ts
@@ -1,0 +1,166 @@
+/**
+ * Wheel-event policy for the terminal pane.
+ *
+ * Two very different panes share one wheel handler:
+ *
+ * - A pane whose foreground app asked tmux for mouse reporting (Claude Code's
+ *   fullscreen TUI) receives wheel reports itself. Those are coordinate
+ *   sensitive and get routed to input history when the pointer sits over the
+ *   prompt box, so we scroll it with PageUp/PageDown instead.
+ * - Every other pane - plain shells, and fullscreen apps like `less` that never
+ *   ask for the mouse - must keep the native path: xterm encodes the wheel as a
+ *   mouse report, tmux enters copy-mode and scrolls its own history. xterm is
+ *   created with `scrollback: 0`, so if we cancel the event nothing scrolls at
+ *   all. Hijacking these panes was issue #24.
+ *
+ * The caller decides nothing; it just obeys the returned action.
+ */
+
+/**
+ * Pixel equivalent of one unit of `deltaY`, indexed by `deltaMode`. These are
+ * the de facto standard conversions (the ones `normalize-wheel` has used for a
+ * decade); an unrecognized mode is treated as pixels.
+ *
+ * They are NOT the pane's row height and must not be "corrected" to it.
+ * Firefox on Windows and Linux reports one notch as `deltaMode: 1` with
+ * `deltaY: 3`, and a 16px line put that notch at 48px - just under the 50px
+ * threshold - so it scrolled nothing at all while an idle timeout kept dropping
+ * the residue between notches. Shrinking these values re-creates that bug.
+ */
+const WHEEL_DELTA_PX_BY_MODE: Record<number, number | undefined> = {
+  0: 1, // DOM_DELTA_PIXEL
+  1: 40, // DOM_DELTA_LINE
+  2: 800, // DOM_DELTA_PAGE
+}
+
+export interface WheelPagerOptions {
+  /**
+   * Pixels of accumulated travel that emit one page. Tuned for macOS
+   * trackpads, which fire many 1-3px events: 160px (the v0.18.7 value) meant a
+   * gentle two-finger swipe never scrolled at all.
+   *
+   * Banked travel is only ever cleared by emitting a page, by reversing
+   * direction, or by leaving the takeover - never by the passage of time. An
+   * idle timeout was tried and removed: any device whose per-notch travel falls
+   * below this threshold depends on residue surviving between notches, so a
+   * timeout starved every such device at cadences slower than the timeout. See
+   * the discrete-wheel tests for the profiles that pins down.
+   *
+   * The cost is that travel banked by an abandoned gesture is still credited to
+   * the next gesture in the same direction, bounded by this threshold. That is
+   * only tolerable because the value is small; at v0.18.7's 160px it would have
+   * banked three pages' worth of trackpad travel.
+   */
+  pageThresholdPx?: number
+  /**
+   * Floor on the gap between emitted pages. macOS keeps sending inertial wheel
+   * events after the fingers lift; without this a flick would fire a dozen
+   * pages.
+   */
+  minIntervalMs?: number
+}
+
+export type PageDirection = 'up' | 'down'
+
+export type WheelAction =
+  /** Let the event through untouched - do NOT preventDefault. */
+  | { type: 'native' }
+  /** Consume the event and scroll the app by one page. */
+  | { type: 'page'; direction: PageDirection }
+  /** Consume the event but scroll nothing yet. */
+  | { type: 'swallow' }
+
+export interface WheelSample {
+  deltaY: number
+  /**
+   * Horizontal travel. Needed to tell a vertical scroll from a sideways swipe,
+   * whose incidental `deltaY` must not be read as paging.
+   */
+  deltaX: number
+  deltaMode: number
+  /** Event timestamp in ms; pass `WheelEvent.timeStamp`. */
+  timeStamp: number
+  /** A macOS trackpad pinch arrives as a wheel event with this set. */
+  ctrlKey: boolean
+  /** Did the pane's foreground app ask tmux for mouse reporting? */
+  mouseApp: boolean
+}
+
+export interface WheelPager {
+  feed(sample: WheelSample): WheelAction
+}
+
+export function createWheelPager(options: WheelPagerOptions = {}): WheelPager {
+  const pageThresholdPx = options.pageThresholdPx ?? 50
+  const minIntervalMs = options.minIntervalMs ?? 60
+
+  let accum = 0
+  let lastPageMs: number | null = null
+
+  /**
+   * Hand the event back to xterm and tmux, dropping buffered travel on the way
+   * out: a takeover can end mid-gesture (Claude Code exiting), and that residue
+   * must never leak into a later one.
+   */
+  function passThrough(): WheelAction {
+    accum = 0
+    return { type: 'native' }
+  }
+
+  /** Is the floor on the gap between pages still down? */
+  function rateLimited(timeStamp: number): boolean {
+    if (lastPageMs === null) return false
+    const sincePage = timeStamp - lastPageMs
+    // Same reasoning on the clock: a negative gap is a boundary, so it must not
+    // read as "too soon", which would suppress every page from then on.
+    return sincePage >= 0 && sincePage < minIntervalMs
+  }
+
+  function feed(sample: WheelSample): WheelAction {
+    const { deltaX, deltaY, deltaMode, timeStamp, ctrlKey, mouseApp } = sample
+
+    // Not our pane: xterm turns the wheel into a mouse report and tmux scrolls
+    // its own history.
+    if (!mouseApp) return passThrough()
+    // Pinch-to-zoom, which macOS delivers as a wheel event with ctrlKey set and
+    // a real deltaY. Cancelling it would page the transcript *and* swallow the
+    // browser zoom; index.html sets no `user-scalable=no`, so zoom is meant to
+    // work. A pinch is its own gesture, so it also ends any scroll in progress.
+    if (ctrlKey) return passThrough()
+    // One frame of a sideways swipe. This is a per-frame classification rather
+    // than a gesture boundary, so it must NOT clear the bank: on a gentle swipe
+    // deltaY is only 1-3px, so 2-4px of lateral noise is enough to "dominate",
+    // and zeroing here let stray sideways frames wipe travel that the vertical
+    // frames had banked - which starved the very device the small threshold
+    // exists to serve.
+    if (Math.abs(deltaX) > Math.abs(deltaY)) return { type: 'native' }
+
+    // A non-finite delta would poison the accumulator: NaN fails every `<`
+    // comparison, so it would slip past the threshold check and emit a page.
+    // Zero is dropped here too, before the sign check below can read
+    // Math.sign(0) as a reversal and wipe a pending bank.
+    if (!Number.isFinite(deltaY) || deltaY === 0) return { type: 'swallow' }
+
+    const px = deltaY * (WHEEL_DELTA_PX_BY_MODE[deltaMode] ?? 1)
+    // A reversal should respond promptly, not spend its first pixels undoing
+    // residue from the opposite direction.
+    if (accum !== 0 && Math.sign(px) !== Math.sign(accum)) accum = 0
+    accum += px
+
+    if (Math.abs(accum) < pageThresholdPx) return { type: 'swallow' }
+
+    if (rateLimited(timeStamp)) {
+      // Discard the travel rather than queueing it, so inertia decays instead
+      // of paying out as a burst of pages once the floor lifts.
+      accum = 0
+      return { type: 'swallow' }
+    }
+
+    const direction: PageDirection = accum < 0 ? 'up' : 'down'
+    accum = 0
+    lastPageMs = timeStamp
+    return { type: 'page', direction }
+  }
+
+  return { feed }
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -22,5 +22,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "vitest.config.ts"]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+// Standalone from vite.config.ts on purpose: the app config loads the PWA plugin
+// and reads TLS certs from ~/.config/lumbergh, none of which pure-logic tests need.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/test/e2e-ui/conftest.py
+++ b/test/e2e-ui/conftest.py
@@ -3,7 +3,7 @@
 import httpx
 import pytest
 from playwright.sync_api import Browser, BrowserContext, Page, expect, sync_playwright
-from pytest_bdd import given, parsers, when
+from pytest_bdd import given, parsers, then, when
 
 
 def pytest_addoption(parser):
@@ -27,6 +27,40 @@ def base_url(request):
 @pytest.fixture(scope="session")
 def repo_dir(request):
     return request.config.getoption("--repo-dir")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _settle_telemetry_consent(base_url):
+    """Record a telemetry decision so the first-run consent modal stays shut.
+
+    What this does: PATCHes `telemetryConsent: false` on the server under test
+    before any scenario runs.
+
+    Why: a fresh install has no `telemetryConsent` at all, and `GET
+    /api/settings` omits the field, so the session page reads it as null and
+    pops the `TelemetryOptIn` consent modal - a `fixed inset-0 z-50` overlay.
+    That overlay intercepts pointer events across the whole viewport, which
+    broke 9 of the 18 UI scenarios on a fresh environment (including the
+    project's own QEMU VM, where settings always start empty). Worse than the
+    failures: a scenario that drives the mouse can still pass while the overlay
+    silently eats the gesture, proving nothing at all.
+
+    It declines rather than accepts, so this can never switch real telemetry
+    on.
+
+    Known side effect: the decision persists in the settings store the tests
+    ran against. On a throwaway VM that is irrelevant, but running the suite
+    against your own dev server writes `telemetryConsent: false` into
+    ~/.config/lumbergh/settings.json and leaves it there. It cannot be undone
+    from here: the PATCH model treats None as "field not provided", so there is
+    no way to express "put it back to undecided" through the API. If you later
+    wonder why telemetry is off and you were never asked, this fixture is why -
+    re-enable it in Settings, or delete the key from settings.json to get the
+    prompt back.
+    """
+    with httpx.Client(base_url=base_url, timeout=10.0) as client:
+        r = client.patch("/api/settings", json={"telemetryConsent": False})
+        assert r.status_code == 200, f"Failed to settle telemetry consent: {r.text}"
 
 
 @pytest.fixture(scope="session")
@@ -130,3 +164,50 @@ def click_tab(page: Page, tab_name: str):
 def navigate_to_session(page: Page, base_url: str, name: str):
     page.goto(f"{base_url}/session/{name}")
     page.wait_for_load_state("networkidle")
+
+
+# Session-creation steps. These live here rather than in test_dashboard.py
+# because both dashboard.feature and dashboard_extended.feature use them, and
+# pytest-bdd only resolves step definitions from the scenario's own module or
+# from conftest - never across test modules. A step defined in one module and
+# used by another feature file fails at collection with
+# StepDefinitionNotFoundError. Steps used by a single feature stay in that
+# feature's module.
+
+
+@when("I click the new session button")
+def click_new_session(page: Page):
+    page.locator('[data-testid="new-session-btn"]').click()
+
+
+@when(parsers.parse('I enter session name "{name}" in the create modal'))
+def enter_session_name(page: Page, name: str):
+    inp = page.locator('[data-testid="session-name-input"]')
+    inp.fill(name)
+
+
+@when("I submit the create session form")
+def submit_create_form(page: Page):
+    btn = page.locator('[data-testid="create-session-submit"]')
+    # Wait for directory validation to complete and button to become enabled
+    expect(btn).to_be_enabled(timeout=10000)
+    btn.click()
+    # After submit, the app navigates to the new session's detail page
+    # Wait for the modal to close as confirmation
+    modal = page.locator('[data-testid="create-session-modal"]')
+    expect(modal).not_to_be_visible(timeout=15000)
+
+
+@then(parsers.parse('I should see the session card for "{name}"'))
+def see_session_card(page: Page, name: str):
+    card = page.locator(f'[data-testid="session-card-{name}"]')
+    expect(card).to_be_visible(timeout=10000)
+
+
+@then(parsers.parse('I should be on the session page for "{name}"'))
+def on_session_page(page: Page, name: str):
+    # The app navigates to /session/{name} after creation
+    page.wait_for_url(f"**/session/{name}", timeout=10000)
+    # Terminal container should be visible on the session detail page
+    terminal = page.locator('[data-testid="terminal-container"]')
+    expect(terminal).to_be_visible(timeout=10000)

--- a/test/e2e-ui/features/session_terminal.feature
+++ b/test/e2e-ui/features/session_terminal.feature
@@ -14,3 +14,11 @@ Feature: Session Terminal
     Then I should see the git tab content
     When I click the "todo" tab
     Then I should see the todo input
+
+  Scenario: Wheeling a plain shell pane does not inject page keys
+    Given a test session exists
+    And I am on the dashboard
+    When I record terminal websocket frames
+    And I click on the session "e2e-ui-session"
+    And I scroll the terminal with the wheel
+    Then no page-key escape sequences are sent to the session

--- a/test/e2e-ui/test_dashboard.py
+++ b/test/e2e-ui/test_dashboard.py
@@ -7,21 +7,14 @@ from pytest_bdd import parsers, scenarios, then, when
 scenarios("features/dashboard.feature")
 
 
-@then(parsers.parse('I should see the session card for "{name}"'))
-def see_session_card(page: Page, name: str):
-    card = page.locator(f'[data-testid="session-card-{name}"]')
-    expect(card).to_be_visible(timeout=10000)
+# Steps shared with dashboard_extended.feature live in conftest.py - see the
+# note there. Only steps this feature alone uses belong in this module.
 
 
 @then(parsers.parse('I should not see the session card for "{name}"'))
 def not_see_session_card(page: Page, name: str):
     card = page.locator(f'[data-testid="session-card-{name}"]')
     expect(card).not_to_be_visible(timeout=10000)
-
-
-@when("I click the new session button")
-def click_new_session(page: Page):
-    page.locator('[data-testid="new-session-btn"]').click()
 
 
 @then("I should see the create session modal")
@@ -36,33 +29,6 @@ def enter_workdir(page: Page, repo_dir: str):
     page.get_by_text("Enter path manually").click()
     inp = page.locator('[data-testid="workdir-input"]')
     inp.fill(f"{repo_dir}/test-repo-2")
-
-
-@when(parsers.parse('I enter session name "{name}" in the create modal'))
-def enter_session_name(page: Page, name: str):
-    inp = page.locator('[data-testid="session-name-input"]')
-    inp.fill(name)
-
-
-@when("I submit the create session form")
-def submit_create_form(page: Page):
-    btn = page.locator('[data-testid="create-session-submit"]')
-    # Wait for directory validation to complete and button to become enabled
-    expect(btn).to_be_enabled(timeout=10000)
-    btn.click()
-    # After submit, the app navigates to the new session's detail page
-    # Wait for the modal to close as confirmation
-    modal = page.locator('[data-testid="create-session-modal"]')
-    expect(modal).not_to_be_visible(timeout=15000)
-
-
-@then(parsers.parse('I should be on the session page for "{name}"'))
-def on_session_page(page: Page, name: str):
-    # The app navigates to /session/{name} after creation
-    page.wait_for_url(f"**/session/{name}", timeout=10000)
-    # Terminal container should be visible on the session detail page
-    terminal = page.locator('[data-testid="terminal-container"]')
-    expect(terminal).to_be_visible(timeout=10000)
 
 
 @when(parsers.parse('I delete the session "{name}"'))

--- a/test/e2e-ui/test_dashboard_extended.py
+++ b/test/e2e-ui/test_dashboard_extended.py
@@ -7,25 +7,11 @@ from pytest_bdd import given, parsers, scenarios, then, when
 scenarios("features/dashboard_extended.feature")
 
 
-# Re-register shared steps needed by this feature's scenarios.
-# pytest-bdd requires step definitions to be in the same module or conftest.
-
-
-@when("I click the new session button")
-def click_new_session(page: Page):
-    page.locator('[data-testid="new-session-btn"]').click()
-
-
-@when(parsers.parse('I enter session name "{name}" in the create modal'))
-def enter_session_name(page: Page, name: str):
-    inp = page.locator('[data-testid="session-name-input"]')
-    inp.fill(name)
-
-
-@then(parsers.parse('I should see the session card for "{name}"'))
-def see_session_card(page: Page, name: str):
-    card = page.locator(f'[data-testid="session-card-{name}"]')
-    expect(card).to_be_visible(timeout=10000)
+# Steps shared with dashboard.feature (clicking new session, entering the name,
+# submitting the form, asserting the session card and the resulting session
+# page) live in conftest.py - see the note there. They used to be copied into
+# this module, which drifted: two of them were never copied, so the scenario
+# that needed them failed at collection.
 
 
 @given("all test sessions are cleaned up")

--- a/test/e2e-ui/test_terminal.py
+++ b/test/e2e-ui/test_terminal.py
@@ -35,3 +35,67 @@ def see_git_tab(page: Page):
 def see_todo_input(page: Page):
     inp = page.locator('[data-testid="todo-input"]')
     expect(inp).to_be_visible(timeout=10000)
+
+
+# ── Issue #24: the wheel must not inject keystrokes into a plain shell ────
+
+# PageUp / PageDown. The client wraps terminal input in JSON, so ESC reaches
+# the wire JSON-escaped; the raw forms are matched too in case the framing
+# ever changes.
+PAGE_KEYS = ("\\u001b[5~", "\\u001b[6~", "\x1b[5~", "\x1b[6~")
+
+
+@when("I record terminal websocket frames", target_fixture="sent_ws_frames")
+def record_ws_frames(page: Page) -> list[str]:
+    """Attach a frame recorder before the terminal WebSocket is opened.
+
+    Must run before navigating to the session: the socket connects as soon as
+    the Terminal component mounts, and a listener attached afterwards sees
+    nothing.
+    """
+    sent: list[str] = []
+
+    def record(payload) -> None:
+        # Playwright hands the frame payload through as str or bytes.
+        sent.append(payload if isinstance(payload, str) else payload.decode("utf-8", "replace"))
+
+    page.on("websocket", lambda ws: ws.on("framesent", record))
+    return sent
+
+
+@when("I scroll the terminal with the wheel")
+def scroll_terminal_with_wheel(page: Page):
+    """Two-finger-swipe-style wheel burst over the middle of the pane."""
+    xterm = page.locator('[data-testid="xterm-container"]')
+    expect(xterm).to_be_visible(timeout=10000)
+    box = xterm.bounding_box()
+    assert box is not None, "xterm container has no bounding box"
+    # Count the wheel events that actually land on the pane. An overlay or a
+    # layout change can swallow the whole gesture, and then "no page keys were
+    # sent" would be true for the wrong reason. Capture phase on the container
+    # runs before the component's own listener on xterm's root, so its
+    # stopPropagation() cannot hide the event from this counter.
+    page.evaluate("""() => {
+      window.__wheelHits = 0
+      document
+        .querySelector('[data-testid="xterm-container"]')
+        .addEventListener('wheel', () => { window.__wheelHits += 1 }, { capture: true, passive: true })
+    }""")
+    page.mouse.move(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
+    # Many small deltas, the way a macOS trackpad two-finger swipe arrives.
+    for _ in range(40):
+        page.mouse.wheel(0, -3)
+    page.wait_for_timeout(500)
+    assert page.evaluate("window.__wheelHits"), (
+        "no wheel event reached the terminal pane - the gesture under test never happened"
+    )
+
+
+@then("no page-key escape sequences are sent to the session")
+def no_page_keys_sent(sent_ws_frames: list[str]):
+    # Guard against a vacuous pass: the client always sends activate/resize
+    # frames on connect, so an empty list means the recorder never saw the
+    # socket and the assertion below would prove nothing.
+    assert sent_ws_frames, "recorder observed no websocket frames at all"
+    offenders = [f for f in sent_ws_frames if any(k in f for k in PAGE_KEYS)]
+    assert not offenders, f"client injected page keys into a plain shell: {offenders}"


### PR DESCRIPTION
Fixes #24.

## The regression

`f439f3f` (v0.18.7) made the terminal's wheel handler cancel **every** wheel event on **every** pane and convert the travel into synthetic `PageUp`/`PageDown`. It was registered `{ capture: true, passive: false }`, so it ran before xterm and stopped the event. Two defects followed:

1. **Every pane that isn't Claude Code lost wheel scrolling.** xterm is created with `scrollback: 0` (tmux owns history), so the only working path for a plain shell was wheel -> xterm mouse report -> tmux copy-mode. `preventDefault()` in the capture phase severs that, and the manual scroll buttons had already been removed. It also wrote `\x1b[5~`/`\x1b[6~` into whatever was running - unsolicited keyboard input at a shell prompt.
2. **160px of travel per page is wrong for a trackpad.** macOS emits many 1-3px `deltaY` values, so a gentle swipe never reached the threshold; when it did, the unit was a whole page. The accumulator was never cleared on direction change or at gesture end.

## The fix

The backend's existing 250ms `#{pane_mode}` poll now also reports tmux's three mouse flags as a `mouse_app` boolean. The client uses it to pick one of two paths:

- `mouse_app` false -> **return without touching the event.** xterm's mouse report reaches tmux, which scrolls its own history. This is the pre-regression behavior.
- `mouse_app` true -> take the wheel over with `PageUp`/`PageDown`.

The decision and all the arithmetic live in `frontend/src/utils/wheelScroll.ts` as a pure state machine, so both are unit-testable without a browser.

### Why the mouse flags and not `alternate_on`

Measured against tmux 3.7:

| Pane state | `alternate_on` | mouse flags | `mouse_app` |
| --- | --- | --- | --- |
| Plain shell | 0 | `000` | false |
| Fullscreen + mouse tracking (Claude Code) | 1 | `100` | **true** |
| Fullscreen, no mouse tracking (`less`) | **1** | `000` | false |
| After the app exits | 0 | `000` | false |

`less` is the row that settles it: fullscreen but never asks for the mouse, so `alternate_on` would have hijacked it and broken its scrolling. The check is "any flag set", since a real mouse-tracking app commonly sets only `mouse_any_flag` (`100`). The flags also survive copy-mode entry, so the decision cannot flip mid-gesture.

If an app is SIGKILLed without restoring modes the flags stay set. tmux is equally confused in that state, so no heuristics are added for it.

### Tuning

A page is the finest unit available here - Claude Code scrolls its transcript on `PageUp`/`PageDown` only, and arrow keys move through input history instead. So the fix comes from the threshold and from accumulator lifetime:

- **50px per page**, down from 160px, with wheel deltas converted using the standard units (40px/line, 800px/page) rather than a 16px guess. At 16px, one Firefox notch on Windows/Linux is 48px against a 50px threshold - swallowed, then discarded. Three of four realistic wheel configurations scrolled **zero** pages.
- **Paging is time-independent.** Travel clears only on emitting a page, reversing direction, or leaving the takeover. An idle timeout was tried and removed: any timeout is a bet on how fast the user turns the wheel, and below it a sub-threshold notch never accumulates. The cost is that an abandoned gesture's travel is credited to the next one in the same direction - bounded by the threshold, and never able to scroll the wrong way.
- **A 60ms floor between pages**, so macOS inertia decays instead of paying out as a burst (2000px over 400ms yields 7 pages, not 40).
- **Pinch and sideways swipes pass through.** macOS delivers a pinch as a wheel event with `ctrlKey` set and a real `deltaY`; at 50px that would page the transcript *and* swallow browser zoom. Horizontal-dominant frames pass through without clearing the bank - that is a per-frame guess rather than a gesture boundary, and clearing there starved gentle swipes.

## Two notes for anyone who read the issue

**`scrollMode` is not dead state.** The issue says nothing sets it to `true` any more; that isn't right. It is set from the `copy_mode` broadcast, and the auto-exit-on-typing logic is live whenever tmux is in copy-mode. It was merely rarely *reached*, because the wheel never got to tmux to enter copy-mode. Restoring the native path makes it reachable again, so no cleanup was needed.

**The `copy_mode` message keeps its type name and `active` field on purpose.** `mouse_app` is additive. The frontend ships inside the Python package, so skew is only ever frontend-older-than-backend (a stale PWA cache); renaming would make a cached frontend drop the message and regress the copy-mode indicator. A missing `mouse_app` coerces to `false`, which is the native path.

## Scope

Desktop wheel, plus the backend signal it needs. The touch-drag path is deliberately unchanged: it also pages without checking `mouse_app`, but mobile already scrolls fine through it, and gating it would remove a working affordance.

`CloudClient.send_json` drops `copy_mode`, so tunnel clients stay on the native path. Forwarding it needs a matching change in the cloud server, which isn't in this repo - only the now-stale comment there was corrected.

## Found and fixed along the way

- **A client joining an already-pooled session never received pane state.** Change-detection lived in the monitor coroutine and the monitor is created once per PTY, so a second client kept `mouse_app` false forever - breaking the wheel in the pop-out window, on a second device, and for a local browser attaching while a tunnel client was connected. State now lives on the session and is replayed on join.
- **The monitor could die on an unexpected exception**, and since `unregister_client` awaits that task, a failed task re-raised and skipped `pty.close()` - leaking the PTY and caching a dead one under that session name. Now guarded, logging the first failure of an outage and recovery once (unthrottled at 4 Hz that is ~231 MiB/day/session, and nothing here configures logging).
- **The tmux probe leaked its pipes** when cancelled mid-poll, or when the reap itself raised. Cleanup is now a single `finally`.
- **A first-run telemetry modal broke 9 of the 18 UI E2E scenarios** on any fresh environment, including the project's own VM - and worse, a mouse-driving scenario could still *pass* while the overlay silently ate the gesture.
- **Two shared step definitions weren't reachable** from `dashboard_extended.feature`, since pytest-bdd only shares steps via `conftest.py`. Suite goes from 17/18 to 18/18.

## Testing

118 backend tests, 31 frontend unit tests (every branch mutation-tested), and a UI E2E scenario asserting a plain shell receives no page keys on a 40-event wheel burst - guarded against passing vacuously by counting the wheel events that actually land on the pane. `./lint.sh` clean.

`vitest` is new, along with a `frontend-test` CI job, since there wasn't one and the pager's tests would otherwise never run in CI. Happy to drop it if you'd rather not take on a second test runner - `wheelScroll.ts` stands alone without its tests, though the arithmetic is the part that already regressed silently once during this PR.
