### PR TITLE
fix(terminal): read clipboard eagerly on Ctrl+V so dictation tools don't lose the restore race

### DIFF
--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -618,10 +618,30 @@ export default memo(function Terminal({
       if (isSessionCycleChord(event)) {
         return false
       }
-      // Decline Ctrl+V so xterm neither sends ^V nor calls preventDefault(). The
-      // browser's own paste then fires and xterm's native paste listener inserts
-      // the text, which is what makes OS-level clipboard injection work.
       if (ctrlVPastesRef.current && isPasteChord(event)) {
+        // Dictation/injection tools (Wispr Flow and similar) write the clipboard,
+        // simulate Ctrl+V, then restore the clipboard's prior contents on a timer.
+        // Waiting for the browser's native paste event to round-trip through this
+        // page's own rendering/WebSocket-heavy main thread can lose that race,
+        // landing the restored (stale) clipboard entry instead of the dictated
+        // text. Where the Clipboard API is available, read it right here in the
+        // keydown handler instead — as fast as this thread can go — and inject it
+        // ourselves, taking over the event with preventDefault() so the native
+        // paste doesn't also fire and double-insert.
+        if (window.isSecureContext && navigator.clipboard?.readText) {
+          event.preventDefault()
+          navigator.clipboard
+            .readText()
+            .then((text) => term.paste(text))
+            .catch(() => {
+              // Permission denied or clipboard empty - nothing to paste.
+            })
+          return false
+        }
+        // Non-secure context (e.g. plain http on a LAN, where navigator.clipboard
+        // is undefined): decline the key without calling preventDefault() so the
+        // browser's own paste fires and xterm's native paste listener inserts the
+        // text from the paste event's clipboardData.
         return false
       }
       if (event.key === 'Enter' && event.shiftKey) {


### PR DESCRIPTION
## The bug

A user reported that when they dictate with Wispr Flow, the terminal sometimes pastes an older clipboard entry instead of the text they just dictated. It's specific to this app — the same dictation setup works fine everywhere else on their machine.

## Why

Wispr Flow (and other dictation/typing tools that work this way) don't type character-by-character. They write the dictated text to the OS clipboard, simulate a Ctrl+V, and then — on a short timer — restore whatever was on the clipboard before they touched it. That's by design, so they don't clobber the user's normal copy/paste. It works because in most apps, Ctrl+V reads the clipboard basically instantly.

e9910f1 fixed Ctrl+V pasting nothing at all, by having it decline the keydown and let the browser's native paste event fire, so xterm's own paste listener could read it. That's the right call for plain-http/LAN setups where `navigator.clipboard` isn't available at all. But it means the actual clipboard read now happens a step later — after a real DOM event dispatch, on the same main thread that's also busy rendering the terminal and handling a live WebSocket stream of PTY output. Under load, that little bit of extra delay is enough for Wispr Flow's own restore-timer to win the race and put the old clipboard content back before this app gets around to reading it. That matches what was reported: not "nothing pastes," but "the wrong, older thing pastes."

## The fix

Where the page is on a secure context (https or localhost) and `navigator.clipboard` is available, read the clipboard directly inside the Ctrl+V keydown handler and paste it in immediately via `term.paste()`, instead of waiting on the native paste event. This is as fast as the browser will let us go, so it should no longer lose the race against a dictation tool's clipboard restore.

For plain-http/LAN setups (where `navigator.clipboard` isn't available), the behavior from e9910f1 is unchanged — decline the key and let the native paste event do the work, same as before.

Everything else (Ctrl+Alt+V for a literal `^V`, Ctrl+Shift+V, and the "Ctrl+V pastes" settings toggle) is untouched.

Feel free to take this in a different direction if you'd rather implement it another way — wanted to get the root cause and a working fix in front of you either way.