### PR TITLE
fix(terminal): recognize Ctrl+V from dictation tools when the key has no physical code

### DIFF
--- a/frontend/src/utils/terminalChords.test.ts
+++ b/frontend/src/utils/terminalChords.test.ts
@@ -113,4 +113,13 @@ describe('Ctrl+V as paste', () => {
   it('matches the physical V key, not the produced character', () => {
     expect(isPasteChord(chord({ code: 'KeyB', key: 'v', ctrlKey: true }))).toBe(false)
   })
+
+  it('falls back to the produced character when code is empty, as dictation tools send', () => {
+    expect(isPasteChord(chord({ code: '', key: 'v', ctrlKey: true }))).toBe(true)
+    expect(isPasteChord(chord({ code: '', key: 'V', ctrlKey: true }))).toBe(true)
+  })
+
+  it('still rejects a non-V key with an empty code', () => {
+    expect(isPasteChord(chord({ code: '', key: 'b', ctrlKey: true }))).toBe(false)
+  })
 })

--- a/frontend/src/utils/terminalChords.ts
+++ b/frontend/src/utils/terminalChords.ts
@@ -42,8 +42,13 @@ export function exitsScrollMode(event: KeyboardEvent): boolean {
 export function isPasteChord(event: KeyboardEvent): boolean {
   if (event.type !== 'keydown') return false
   if (event.shiftKey || event.altKey) return false
-  // Physical key position: on a non-QWERTY layout the key labelled V is not the
-  // one the OS paste shortcut uses, and the OS shortcut is what we are matching.
-  if (event.code !== 'KeyV') return false
+  // Physical key position, preferred: on a non-QWERTY layout the key labelled V
+  // is not the one the OS paste shortcut uses, and the OS shortcut is what we
+  // are matching. But dictation/injection tools (Wispr Flow and friends) send a
+  // trusted, OS-level Ctrl+V whose `code` is sometimes empty - there's no
+  // physical key behind it, so there's nothing to report. Fall back to the
+  // produced character in that case rather than dropping the paste.
+  const matchesV = event.code ? event.code === 'KeyV' : event.key.toLowerCase() === 'v'
+  if (!matchesV) return false
   return event.ctrlKey !== event.metaKey
 }


### PR DESCRIPTION
## The bug

A user reported that dictating with Wispr Flow into the terminal sometimes pastes old/wrong text instead of what they just said. It only happened in the terminal view, not in the chat reply box or anywhere else in the app, and it was intermittent - sometimes fine, sometimes not.

## Why

e9910f1 fixed Ctrl+V being silently swallowed as a literal `^V`, by declining the key so the browser's native paste can fire instead. That decline logic (`isPasteChord` in `terminalChords.ts`) checks `event.code === 'KeyV'` - the physical key position - on purpose, so it keeps working correctly on non-QWERTY keyboard layouts.

Turns out Wispr Flow's simulated Ctrl+V keystroke doesn't always come with a physical key code attached - `event.code` shows up as an empty string, even though it's a real, trusted, OS-level key event and `event.key` correctly says `"v"`. When `code` is empty, our check never matches, so the paste never gets declined, and the keystroke falls through to whatever handles an unrecognized key instead of the working path from e9910f1. That's what produced the wrong text - confirmed by adding some temporary console logging and reproducing it live with real dictation.

## The fix

`isPasteChord` now falls back to the produced character (`event.key`) only when `event.code` is empty. When a real physical key code is present, it still checks that first, so the Dvorak/AZERTY handling e9910f1 cared about is untouched.

Tested live against real Wispr Flow dictation on this branch and confirmed it now pastes correctly and consistently.