### PR TITLE
Quick-collapse toggle for the right panel

### DIFF
--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import {
   ArrowLeft,
+  ChevronsLeft,
+  ChevronsRight,
   Folder,
   GitBranch,
   ListTodo,
@@ -38,6 +40,7 @@ import { useConversationScale } from '../hooks/useConversationScale'
 import ZenTerminal from '../components/ZenTerminal'
 import { useFocusMode } from '../hooks/useFocusMode'
 import { paneLayout } from '../utils/focusMode'
+import type { FocusTarget } from '../utils/focusMode'
 
 type RightPanel = 'git' | 'files' | 'todos' | 'prompts' | 'shared'
 type MobileTab = 'terminal' | 'git' | 'files' | 'todos' | 'prompts' | 'shared'
@@ -76,6 +79,30 @@ const PANEL_LABELS: Record<string, string> = {
 
 function panelLabel(panel: string): string {
   return PANEL_LABELS[panel] ?? 'This panel'
+}
+
+// The quick "hide side panels" toggle only steps in when focus/maximize state
+// leaves the layout's own collapse unset -- once either forces a side, this
+// toggle has nothing to add.
+function resolveCollapse(
+  layoutCollapse: 'left' | 'right' | null,
+  rightPaneCollapsed: boolean
+): 'left' | 'right' | null {
+  if (layoutCollapse) return layoutCollapse
+  return rightPaneCollapsed ? 'right' : null
+}
+
+function canQuickCollapse(maximized: boolean, isTerminalOnly: boolean): boolean {
+  return !maximized && !isTerminalOnly
+}
+
+function canQuickRestore(
+  isTerminalOnly: boolean,
+  rightPaneCollapsed: boolean,
+  focus: FocusTarget,
+  maximized: boolean
+): boolean {
+  return !isTerminalOnly && rightPaneCollapsed && focus !== 'main' && !maximized
 }
 
 function diffDataEquals(a: DiffData | null, b: DiffData | null): boolean {
@@ -221,11 +248,19 @@ export default function SessionDetail() {
 
   const isTerminalOnly = visibleTabs.length === 0
 
-  const { maximized, terminalMaximized, terminalVisible, collapse } = paneLayout(
-    focus,
-    fullPane,
-    isTerminalOnly
-  )
+  // Quick, non-persisted "get it out of my way" toggle for the right pane
+  // group. Deliberately separate from tabVisibility (the gear icon's
+  // persisted, global/session setting) -- this is local UI state that resets
+  // on reload rather than a saved preference.
+  const [rightPaneCollapsed, setRightPaneCollapsed] = useState(false)
+
+  const {
+    maximized,
+    terminalMaximized,
+    terminalVisible,
+    collapse: layoutCollapse,
+  } = paneLayout(focus, fullPane, isTerminalOnly)
+  const collapse = resolveCollapse(layoutCollapse, rightPaneCollapsed)
 
   const handleTogglePanel = useCallback(() => {
     setFullPane('panel')
@@ -639,6 +674,19 @@ export default function SessionDetail() {
   // terminal.
   const renderPanelTabs = () => (
     <div className="flex gap-1 p-2 bg-bg-surface border-b border-border-default">
+      {canQuickCollapse(maximized, isTerminalOnly) && (
+        <>
+          <button
+            onClick={() => setRightPaneCollapsed(true)}
+            data-testid="panel-quick-collapse"
+            className="px-2 py-1 rounded text-text-tertiary hover:text-text-secondary hover:bg-control-bg-hover transition-colors"
+            title="Hide side panels"
+          >
+            <ChevronsRight size={14} />
+          </button>
+          <div className="w-px bg-border-default my-1" />
+        </>
+      )}
       {maximized && (
         <button
           data-testid="tab-terminal"
@@ -856,10 +904,21 @@ export default function SessionDetail() {
                   {isTerminalOnly && focus !== 'main' && (
                     <button
                       onClick={() => saveSessionTabVisibility({ ...globalTabVisibility })}
-                      className="absolute top-2 right-2 px-2 py-1 rounded bg-bg-surface/80 border border-border-default text-text-tertiary hover:text-text-primary text-xs transition-colors backdrop-blur-sm"
+                      className="absolute top-14 right-2 px-2 py-1 rounded bg-bg-surface/80 border border-border-default text-text-tertiary hover:text-text-primary text-xs transition-colors backdrop-blur-sm flex items-center gap-1"
                       title="Show side panels"
                     >
+                      <ChevronsLeft size={14} />
                       Tabs
+                    </button>
+                  )}
+                  {canQuickRestore(isTerminalOnly, rightPaneCollapsed, focus, maximized) && (
+                    <button
+                      onClick={() => setRightPaneCollapsed(false)}
+                      className="absolute top-14 right-2 px-2 py-1 rounded bg-bg-surface/80 border border-border-default text-text-tertiary hover:text-text-primary text-xs transition-colors backdrop-blur-sm flex items-center gap-1"
+                      title="Show side panels"
+                    >
+                      <ChevronsLeft size={14} />
+                      Panels
                     </button>
                   )}
                 </div>

--- a/frontend/src/utils/terminalChords.test.ts
+++ b/frontend/src/utils/terminalChords.test.ts
@@ -113,4 +113,13 @@ describe('Ctrl+V as paste', () => {
   it('matches the physical V key, not the produced character', () => {
     expect(isPasteChord(chord({ code: 'KeyB', key: 'v', ctrlKey: true }))).toBe(false)
   })
+
+  it('falls back to the produced character when code is empty, as dictation tools send', () => {
+    expect(isPasteChord(chord({ code: '', key: 'v', ctrlKey: true }))).toBe(true)
+    expect(isPasteChord(chord({ code: '', key: 'V', ctrlKey: true }))).toBe(true)
+  })
+
+  it('still rejects a non-V key with an empty code', () => {
+    expect(isPasteChord(chord({ code: '', key: 'b', ctrlKey: true }))).toBe(false)
+  })
 })

--- a/frontend/src/utils/terminalChords.ts
+++ b/frontend/src/utils/terminalChords.ts
@@ -42,8 +42,13 @@ export function exitsScrollMode(event: KeyboardEvent): boolean {
 export function isPasteChord(event: KeyboardEvent): boolean {
   if (event.type !== 'keydown') return false
   if (event.shiftKey || event.altKey) return false
-  // Physical key position: on a non-QWERTY layout the key labelled V is not the
-  // one the OS paste shortcut uses, and the OS shortcut is what we are matching.
-  if (event.code !== 'KeyV') return false
+  // Physical key position, preferred: on a non-QWERTY layout the key labelled V
+  // is not the one the OS paste shortcut uses, and the OS shortcut is what we
+  // are matching. But dictation/injection tools (Wispr Flow and friends) send a
+  // trusted, OS-level Ctrl+V whose `code` is sometimes empty - there's no
+  // physical key behind it, so there's nothing to report. Fall back to the
+  // produced character in that case rather than dropping the paste.
+  const matchesV = event.code ? event.code === 'KeyV' : event.key.toLowerCase() === 'v'
+  if (!matchesV) return false
   return event.ctrlKey !== event.metaKey
 }


### PR DESCRIPTION
## Summary

Adds a one-click, non-persisted toggle to hide the right panel group (git/files/todos/prompts/shared) and give the terminal full width, then bring it back.

The existing "Terminal Only" setting (gear icon) is global/persisted and meant for a lasting layout preference. It's too heavy for the common case of just wanting the terminal wide for a moment — e.g. bouncing between a half-screen split and a full-width terminal while reading a long agent response, then wanting the side panel back. Flipping that setting repeatedly for this meant digging into a settings menu each time. This toggle is local UI state that resets on reload, sitting next to the panel tabs, with a matching restore affordance when collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)